### PR TITLE
EVG-17677: Align log lines by setting fixed width for line number

### DIFF
--- a/src/components/LogRow/AnsiiRow/__snapshots__/AnsiiRow.stories.storyshot
+++ b/src/components/LogRow/AnsiiRow/__snapshots__/AnsiiRow.stories.storyshot
@@ -40,7 +40,7 @@ exports[`storyshots Storyshots Components/LogRow/AnsiiRow Multi Lines 1`] = `
 
 exports[`storyshots Storyshots Components/LogRow/AnsiiRow Single Line 1`] = `
 <pre
-  className="css-1j2roh1"
+  className="css-rpdi2m"
   data-cy="log-row-0"
   onDoubleClick={[Function]}
   selected={false}
@@ -68,7 +68,7 @@ exports[`storyshots Storyshots Components/LogRow/AnsiiRow Single Line 1`] = `
     />
   </svg>
   <span
-    className="css-1bxf48m"
+    className="css-1ix6uu2"
   >
     0
   </span>

--- a/src/components/LogRow/BaseRow/index.tsx
+++ b/src/components/LogRow/BaseRow/index.tsx
@@ -86,8 +86,10 @@ const StyledIcon = styled(Icon)`
 `;
 
 const Index = styled.span`
+  display: inline-block;
+  width: ${size.xl};
   margin-left: ${size.s};
-  margin-right: ${size.xl};
+  margin-right: ${size.s};
   user-select: none;
 `;
 
@@ -102,6 +104,7 @@ const StyledPre = styled.pre<{
   margin-bottom: 0;
   margin-right: ${size.xs};
   font-size: ${fontSize.m};
+  word-break: break-all;
   ${({ shouldWrap }) =>
     shouldWrap
       ? `

--- a/src/components/LogRow/ResmokeRow/__snapshots__/ResmokeRow.stories.storyshot
+++ b/src/components/LogRow/ResmokeRow/__snapshots__/ResmokeRow.stories.storyshot
@@ -40,7 +40,7 @@ exports[`storyshots Storyshots Components/LogRow/ResmokeRow Multiple Lines 1`] =
 
 exports[`storyshots Storyshots Components/LogRow/ResmokeRow Single Line 1`] = `
 <pre
-  className="css-1j2roh1"
+  className="css-rpdi2m"
   data-cy="log-row-2"
   onDoubleClick={[Function]}
   selected={false}
@@ -68,7 +68,7 @@ exports[`storyshots Storyshots Components/LogRow/ResmokeRow Single Line 1`] = `
     />
   </svg>
   <span
-    className="css-1bxf48m"
+    className="css-1ix6uu2"
   >
     2
   </span>


### PR DESCRIPTION
EVG-17677

### Description 
Log lines are currently not always aligned due to log line numbers being able to have different lengths (e.g. `1` vs `99` vs `100`).

This PR sets a fixed width for the line number so that the log lines are always aligned at the same starting point.

### Screenshots
<img width="412" alt="Screen Shot 2022-09-13 at 11 42 36 AM" src="https://user-images.githubusercontent.com/47064971/189959449-5b90d903-66c3-41fc-bf5b-49c8a28ea13a.png">


### Testing 
- Manually looking 👀
