### PR TITLE
EVG-17914 Add code splitting to produce smaller bundles

### DIFF
--- a/src/components/LogRow/AnsiiRow/AnsiiRow.stories.tsx
+++ b/src/components/LogRow/AnsiiRow/AnsiiRow.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { MemoryRouter } from "react-router-dom";
 import LogPane from "components/LogPane";
 import { LogTypes } from "constants/enums";
-import { AnsiiRow } from ".";
+import AnsiiRow from ".";
 import { RowRenderer, cache } from "../RowRenderer";
 
 export default {

--- a/src/components/LogRow/AnsiiRow/AnsiiRow.test.tsx
+++ b/src/components/LogRow/AnsiiRow/AnsiiRow.test.tsx
@@ -1,7 +1,7 @@
 import { LogTypes } from "constants/enums";
 import { LogContextProvider } from "context/LogContext";
 import { renderWithRouterMatch, screen, userEvent, waitFor } from "test_utils";
-import { AnsiiRow } from ".";
+import AnsiiRow from ".";
 
 const wrapper = (logs: string[]) => {
   const provider = ({ children }: { children: React.ReactNode }) => (

--- a/src/components/LogRow/AnsiiRow/index.tsx
+++ b/src/components/LogRow/AnsiiRow/index.tsx
@@ -47,4 +47,4 @@ const ProcessedAnsiiRow: React.FC<ProcessedAnsiiRowProps> = ({
 
 AnsiiRow.displayName = "AnsiiRow";
 
-export { AnsiiRow };
+export default AnsiiRow;

--- a/src/components/LogRow/ResmokeRow/ResmokeRow.stories.tsx
+++ b/src/components/LogRow/ResmokeRow/ResmokeRow.stories.tsx
@@ -1,11 +1,10 @@
 import styled from "@emotion/styled";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { MemoryRouter } from "react-router-dom";
-
 import LogPane from "components/LogPane";
 import { RowRenderer, cache } from "components/LogRow/RowRenderer";
 import { LogTypes } from "constants/enums";
-import { ResmokeRow } from ".";
+import ResmokeRow from ".";
 
 export default {
   title: "Components/LogRow/ResmokeRow",

--- a/src/components/LogRow/ResmokeRow/ResmokeRow.test.tsx
+++ b/src/components/LogRow/ResmokeRow/ResmokeRow.test.tsx
@@ -1,7 +1,7 @@
 import { LogTypes } from "constants/enums";
 import { LogContextProvider } from "context/LogContext";
 import { renderWithRouterMatch, screen, userEvent, waitFor } from "test_utils";
-import { ResmokeRow } from ".";
+import ResmokeRow from ".";
 
 const wrapper = (logs: string[]) => {
   const provider = ({ children }: { children: React.ReactNode }) => (

--- a/src/components/LogRow/ResmokeRow/index.tsx
+++ b/src/components/LogRow/ResmokeRow/index.tsx
@@ -21,4 +21,4 @@ const ResmokeRow = forwardRef<any, BaseRowProps>((rowProps, ref) => {
 
 ResmokeRow.displayName = "ResmokeRow";
 
-export { ResmokeRow };
+export default ResmokeRow;

--- a/src/components/LogRow/RowRenderer/index.tsx
+++ b/src/components/LogRow/RowRenderer/index.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy } from "react";
+import { Suspense, lazy } from "react";
 import {
   CellMeasurer,
   CellMeasurerCache,
@@ -6,7 +6,7 @@ import {
   ListRowRenderer,
 } from "react-virtualized";
 import { LogTypes } from "constants/enums";
-import { ResmokeRow } from "../ResmokeRow";
+import ResmokeRow from "../ResmokeRow";
 import { RowData } from "../types";
 
 const AnsiiRow = lazy(() => import("../AnsiiRow"));

--- a/src/components/LogRow/RowRenderer/index.tsx
+++ b/src/components/LogRow/RowRenderer/index.tsx
@@ -1,3 +1,4 @@
+import React, { Suspense, lazy } from "react";
 import {
   CellMeasurer,
   CellMeasurerCache,
@@ -5,9 +6,10 @@ import {
   ListRowRenderer,
 } from "react-virtualized";
 import { LogTypes } from "constants/enums";
-import { AnsiiRow } from "../AnsiiRow";
 import { ResmokeRow } from "../ResmokeRow";
 import { RowData } from "../types";
+
+const AnsiiRow = lazy(() => import("../AnsiiRow"));
 
 type RowRendererFunction = (data: RowData) => ListRowRenderer;
 
@@ -29,9 +31,14 @@ const RowRenderer: RowRendererFunction = (data) => {
   return result;
 };
 
+const SuspendedAnsiiRow = (props: React.ComponentProps<typeof AnsiiRow>) => (
+  <Suspense fallback={<div>Loading...</div>}>
+    <AnsiiRow {...props} />
+  </Suspense>
+);
 const rowRendererMap = {
-  [LogTypes.EVERGREEN_TASK_LOGS]: AnsiiRow,
-  [LogTypes.EVERGREEN_TEST_LOGS]: AnsiiRow,
+  [LogTypes.EVERGREEN_TASK_LOGS]: SuspendedAnsiiRow,
+  [LogTypes.EVERGREEN_TEST_LOGS]: SuspendedAnsiiRow,
   [LogTypes.RESMOKE_LOGS]: ResmokeRow,
 };
 

--- a/src/components/LogRow/index.ts
+++ b/src/components/LogRow/index.ts
@@ -1,4 +1,0 @@
-import { AnsiiRow } from "./AnsiiRow";
-import { ResmokeRow } from "./ResmokeRow";
-
-export { AnsiiRow, ResmokeRow };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,21 @@
+import { Suspense, lazy } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { LogTypes } from "constants/enums";
 import routes from "constants/routes";
-import LogDrop from "./LogDrop";
 import LogView from "./LogView";
 
+const LogDrop = lazy(() => import("./LogDrop"));
 const Content: React.FC = () => (
   <Routes>
     <Route element={<Navigate to={routes.upload} />} path={routes.root} />
-    <Route element={<LogDrop />} path={routes.upload} />
+    <Route
+      element={
+        <Suspense fallback={<div>Loading...</div>}>
+          <LogDrop />
+        </Suspense>
+      }
+      path={routes.upload}
+    />
     <Route
       element={<LogView logType={LogTypes.EVERGREEN_TASK_LOGS} />}
       path={routes.evergreenLogs}


### PR DESCRIPTION
EVG-17914

### Description 
Our main bundle has gotten kind of big due to some dependencies that most users may not ever interact with. (LogUploader , Logs with AnsiiRow) So i thought it would make sense to split out those deps into their own bundles.

### Screenshots
bundle before:
<img width="1487" alt="image" src="https://user-images.githubusercontent.com/4605522/190667620-6434ba99-51ff-49f7-af05-bf6e563b5435.png">

bundle after:
<img width="1483" alt="image" src="https://user-images.githubusercontent.com/4605522/190667821-208a65af-4f97-4e06-a0de-11ce86339f37.png">
