### PR TITLE
EVG-17539 Adjust resmoke function processing

### DIFF
--- a/src/utils/resmoke/helpers.test.ts
+++ b/src/utils/resmoke/helpers.test.ts
@@ -130,21 +130,17 @@ describe("resmoke/helpers", () => {
       expect(getResmokeFunction("hello")).toBeUndefined();
     });
     it("returns undefined if a line has a resmoke function but no json", () => {
-      expect(getResmokeFunction("[j1] hello")).toBeUndefined();
-      expect(getResmokeFunction("[j2] hello")).toBeUndefined();
-      expect(getResmokeFunction("[j0:s0:n2] hello")).toBeUndefined();
+      expect(getResmokeFunction("[j1] hello")).toBe("[j1]");
+      expect(getResmokeFunction("[j2] hello")).toBe("[j2]");
+      expect(getResmokeFunction("[j0:s0:n2] hello")).toBe("[j0:s0:n2]");
     });
     it("returns a resmoke function correctly", () => {
-      expect(
-        getResmokeFunction(
-          `[js_test:fle_agg] {"t":{"$date":"2022-09-21T22:11:21.630Z"},"s":"I",  "c":"-",        "id":22810,   "ctx":"js","msg":"shell: Started program","attr":{"pid":"21666","port":-1,"argv":["/data/mci/dc8eb627f29b4cfe1d70952dac9eb6d7/src/dist-test/bin/mongocryptd","--port=20540","--unixSocketPrefix=/data/db/job2/mongorunner","--setParameter","featureFlagFLE2Range=true","--setParameter","enableTestCommands=1","-vvv","--pidfilepath=/data/db/job2/mongorunner/cryptd.pid"]}}`
-        )
-      ).toBe(`[js_test:fle_agg]`);
-      expect(
-        getResmokeFunction(
-          `[js_test:fle_agg] sh21666| {"t":{"$date":"2022-09-21T22:11:23.637+00:00"},"s":"I",  "c":"NETWORK",  "id":4648602, "ctx":"main","msg":"Implicit TCP FastOpen in use."}`
-        )
-      ).toBe("[js_test:fle_agg]");
+      expect(getResmokeFunction(`[js_test:fle_agg] `)).toBe(
+        `[js_test:fle_agg]`
+      );
+      expect(getResmokeFunction(`[js_test:fle_agg] sh21666| `)).toBe(
+        "[js_test:fle_agg]"
+      );
     });
   });
   describe("getShellPrefix", () => {

--- a/src/utils/resmoke/helpers.test.ts
+++ b/src/utils/resmoke/helpers.test.ts
@@ -129,7 +129,7 @@ describe("resmoke/helpers", () => {
     it("handles strings without resmoke", () => {
       expect(getResmokeFunction("hello")).toBeUndefined();
     });
-    it("returns undefined if a line has a resmoke function but no json", () => {
+    it("returns resmoke function on a normal line", () => {
       expect(getResmokeFunction("[j1] hello")).toBe("[j1]");
       expect(getResmokeFunction("[j2] hello")).toBe("[j2]");
       expect(getResmokeFunction("[j0:s0:n2] hello")).toBe("[j0:s0:n2]");

--- a/src/utils/resmoke/helpers.test.ts
+++ b/src/utils/resmoke/helpers.test.ts
@@ -129,10 +129,22 @@ describe("resmoke/helpers", () => {
     it("handles strings without resmoke", () => {
       expect(getResmokeFunction("hello")).toBeUndefined();
     });
-    it("handles strings with resmoke", () => {
-      expect(getResmokeFunction("[j1] hello")).toBe("[j1]");
-      expect(getResmokeFunction("[j2] hello")).toBe("[j2]");
-      expect(getResmokeFunction("[j0:s0:n2] hello")).toBe("[j0:s0:n2]");
+    it("returns undefined if a line has a resmoke function but no json", () => {
+      expect(getResmokeFunction("[j1] hello")).toBeUndefined();
+      expect(getResmokeFunction("[j2] hello")).toBeUndefined();
+      expect(getResmokeFunction("[j0:s0:n2] hello")).toBeUndefined();
+    });
+    it("returns a resmoke function correctly", () => {
+      expect(
+        getResmokeFunction(
+          `[js_test:fle_agg] {"t":{"$date":"2022-09-21T22:11:21.630Z"},"s":"I",  "c":"-",        "id":22810,   "ctx":"js","msg":"shell: Started program","attr":{"pid":"21666","port":-1,"argv":["/data/mci/dc8eb627f29b4cfe1d70952dac9eb6d7/src/dist-test/bin/mongocryptd","--port=20540","--unixSocketPrefix=/data/db/job2/mongorunner","--setParameter","featureFlagFLE2Range=true","--setParameter","enableTestCommands=1","-vvv","--pidfilepath=/data/db/job2/mongorunner/cryptd.pid"]}}`
+        )
+      ).toBe(`[js_test:fle_agg]`);
+      expect(
+        getResmokeFunction(
+          `[js_test:fle_agg] sh21666| {"t":{"$date":"2022-09-21T22:11:23.637+00:00"},"s":"I",  "c":"NETWORK",  "id":4648602, "ctx":"main","msg":"Implicit TCP FastOpen in use."}`
+        )
+      ).toBe("[js_test:fle_agg]");
     });
   });
   describe("getShellPrefix", () => {

--- a/src/utils/resmoke/helpers.ts
+++ b/src/utils/resmoke/helpers.ts
@@ -18,16 +18,7 @@ const resmokeFunctionRegex = /\[.*\]/g;
 
 /** `getResmokeFunction` returns the resmoke function that ran a resmoke line */
 const getResmokeFunction = (line: string) => {
-  let logParts = line.split("|"); // in many cases mongod will insert a pipe between the metadata and json logs
-  if (logParts.length !== 2) {
-    const startOfJson = line.indexOf("{"); // if not, attempt to find the first occurence of a json document and attempt to parse as a log
-    if (startOfJson > -1) {
-      logParts = [line.substring(0, startOfJson)];
-    } else {
-      return undefined;
-    }
-  }
-  const resmokeFunction = logParts[0].match(resmokeFunctionRegex)?.[0];
+  const resmokeFunction = line.match(resmokeFunctionRegex)?.[0];
   return resmokeFunction;
 };
 

--- a/src/utils/resmoke/helpers.ts
+++ b/src/utils/resmoke/helpers.ts
@@ -22,7 +22,7 @@ const getResmokeFunction = (line: string) => {
   if (logParts.length !== 2) {
     const startOfJson = line.indexOf("{"); // if not, attempt to find the first occurence of a json document and attempt to parse as a log
     if (startOfJson > -1) {
-      logParts = [line.substring(0, startOfJson), line.substring(startOfJson)];
+      logParts = [line.substring(0, startOfJson)];
     } else {
       return undefined;
     }

--- a/src/utils/resmoke/helpers.ts
+++ b/src/utils/resmoke/helpers.ts
@@ -2,7 +2,7 @@
  * @example s12345
  * @example d54321
  */
-const portRegex = / ([sdbc]\d{1,5})\|/;
+const portRegex = / ([shdbc]+\d{1,5})\|/;
 
 /** `getPort` returns the port associated with a resmoke line */
 const getPort = (line: string) => {
@@ -18,7 +18,16 @@ const resmokeFunctionRegex = /\[.*\]/g;
 
 /** `getResmokeFunction` returns the resmoke function that ran a resmoke line */
 const getResmokeFunction = (line: string) => {
-  const resmokeFunction = line.match(resmokeFunctionRegex)?.[0];
+  let logParts = line.split("|"); // in many cases mongod will insert a pipe between the metadata and json logs
+  if (logParts.length !== 2) {
+    const startOfJson = line.indexOf("{"); // if not, attempt to find the first occurence of a json document and attempt to parse as a log
+    if (startOfJson > -1) {
+      logParts = [line.substring(0, startOfJson), line.substring(startOfJson)];
+    } else {
+      return undefined;
+    }
+  }
+  const resmokeFunction = logParts[0].match(resmokeFunctionRegex)?.[0];
   return resmokeFunction;
 };
 

--- a/src/utils/resmoke/index.ts
+++ b/src/utils/resmoke/index.ts
@@ -23,6 +23,9 @@ const processResmokeLine = (line: string) => {
   if (!json) {
     return line;
   }
+  if (!(getPid(json) && getShellPrefix(json) && getContext(json))) {
+    return line;
+  }
 
   const port = getPort(line) ?? "";
   const timeStamp = getTimeStamp(json) ?? "";

--- a/src/utils/resmoke/index.ts
+++ b/src/utils/resmoke/index.ts
@@ -12,17 +12,29 @@ import {
 } from "./helpers";
 
 const processResmokeLine = (line: string) => {
+  let logParts = line.split("|"); // in many cases mongod will insert a pipe between the metadata and json logs
+  if (logParts.length !== 2) {
+    const startOfJson = line.indexOf("{"); // if not, attempt to find the first occurrence of a json document and attempt to parse as a log
+    if (startOfJson > -1) {
+      logParts = [line.substring(0, startOfJson), line.substring(startOfJson)];
+    } else {
+      return line;
+    }
+  }
+
   // First check if it is a resmoke line at all
-  const resmokeFunction = getResmokeFunction(line);
+  const resmokeFunction = getResmokeFunction(logParts[0]);
   if (!resmokeFunction) {
     return line;
   }
   // Try to get the JSON string in the resmoke line
   // If there is no JSON string, return the line as is
-  const json = getJSONString(line);
+  const json = getJSONString(logParts[1]);
   if (!json) {
     return line;
   }
+
+  // Sometimes a line may have some json but it isn't a resmoke line so we need to check to see if it has the following resmoke fields
   if (!(getPid(json) && getShellPrefix(json) && getContext(json))) {
     return line;
   }


### PR DESCRIPTION
EVG-17539

### Description 
Upon further investigation of resmoke lines i discovered mongod does not always separate the resmoke function with a pipe. So we need to add some further processing to separate the function.
### Screenshots
example bad lines
![image](https://user-images.githubusercontent.com/4605522/191762938-60d2315e-afe5-48aa-92dd-a6152bff3caf.png)
