### PR TITLE
EVG-17965 Ensure test results are attached

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -318,7 +318,6 @@ tasks:
   - name: test
     commands:
     - func: yarn-test
-    - func: attach-test-results
 
   - name: e2e_test
     commands:
@@ -336,10 +335,6 @@ tasks:
     - func: yarn-preview
     - func: install-chrome
     - func: yarn-cypress
-    - func: attach-cypress-results
-    - func: attach-cypress-screenshots
-    - func: attach-cypress-videos
-    - func: attach-logkeeper-logs
 
   - name: storybook
     commands:
@@ -379,3 +374,11 @@ buildvariants:
 pre:
   - func: get-project
   - func: yarn-install
+
+post:
+  - func: attach-results
+  - func: attach-cypress-results
+  - func: attach-cypress-screenshots
+  - func: attach-cypress-videos
+  - func: attach-logkeeper-logs
+  - func: attach-test-results

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -346,7 +346,6 @@ tasks:
   - name: snapshots
     commands:
     - func: yarn-snapshot
-    - func: attach-test-results
 
 buildvariants:
   - name: ubuntu1604-small

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -375,7 +375,6 @@ pre:
   - func: yarn-install
 
 post:
-  - func: attach-results
   - func: attach-cypress-results
   - func: attach-cypress-screenshots
   - func: attach-cypress-videos

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -112,7 +112,7 @@ functions:
       bucket: mciuploads
       content_type: text/html
       permissions: public-read
-      display_name: source_map_
+      display_name: source_map
     
   copy-cmdrc:
     command: shell.exec


### PR DESCRIPTION
EVG-17965 

### Description 
Relocate attach results functions to `post` command. Evergreen stops running a task if one of its commands fail.
 So it was never uploading any test results or artifacts for a failing test. 
