### PR TITLE
EVG_18007 test_utils now wraps element wrappers in router

### DIFF
--- a/src/test_utils/index.tsx
+++ b/src/test_utils/index.tsx
@@ -59,25 +59,28 @@ const renderWithRouterMatch = (
     route = "/",
     history = createMemoryHistory({ initialEntries: [route] }),
     path = "/",
+    wrapper: TestWrapper,
     ...rest
   } = options;
-  const { rerender, ...renderRest } = customRender(
+  const wrapper = ({ children }: { children: any }) => (
     <HistoryRouter history={history}>
       <Routes>
-        <Route element={ui} path={path} />
+        <Route
+          element={
+            TestWrapper ? <TestWrapper>{children}</TestWrapper> : children
+          }
+          path={path}
+        />
       </Routes>
-    </HistoryRouter>,
-    rest
+    </HistoryRouter>
   );
+
+  const { rerender, ...renderRest } = customRender(ui, { ...rest, wrapper });
+
   const customRerender = (element: React.ReactElement) => {
-    rerender(
-      <HistoryRouter history={history}>
-        <Routes>
-          <Route element={element} path={path} />
-        </Routes>
-      </HistoryRouter>
-    );
+    rerender(element);
   };
+
   return {
     history,
     rerender: customRerender,


### PR DESCRIPTION
EVG-18007

### Description 
Ran into this while writing tests for EVG-17528. Any elements that are passed into the wrapper prop aren't actually wrapped with a react router instance. This prevents us from using react router within a context.

