### PR TITLE
EVG-17622: Add keyboard shortcuts

### DIFF
--- a/src/components/FiltersDrawer/index.tsx
+++ b/src/components/FiltersDrawer/index.tsx
@@ -9,6 +9,7 @@ import Icon from "components/Icon";
 import { HAS_OPENED_DRAWER } from "constants/cookies";
 import { QueryParams } from "constants/queryParams";
 import { size, zIndex } from "constants/tokens";
+import { useKeyboardShortcut } from "hooks";
 import { useQueryParam } from "hooks/useQueryParam";
 import Filter from "./Filter";
 
@@ -22,6 +23,8 @@ const FiltersDrawer: React.FC<FiltersDrawerProps> = ({ "data-cy": dataCy }) => {
   const [collapsed, setCollapsed] = useState(
     Cookie.get(HAS_OPENED_DRAWER) === "true"
   );
+
+  useKeyboardShortcut(["Control", "d"], () => setCollapsed(!collapsed));
 
   const [filters, setFilters] = useQueryParam<string[]>(
     QueryParams.Filters,

--- a/src/components/SearchBar/SearchBar.test.tsx
+++ b/src/components/SearchBar/SearchBar.test.tsx
@@ -50,4 +50,14 @@ describe("searchbar", () => {
     expect(input).toHaveValue("test");
     expect(onSubmit).not.toHaveBeenCalled();
   });
+  it("pressing Control+F puts focus on the input", async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSubmit={jest.fn()} />);
+
+    const input = screen.getByDataCy("searchbar-input");
+    expect(input).not.toHaveFocus();
+
+    await user.keyboard("{Control>}{f}");
+    expect(input).toHaveFocus();
+  });
 });

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEvent, useState } from "react";
+import { KeyboardEvent, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import IconButton from "@leafygreen-ui/icon-button";
 import { palette } from "@leafygreen-ui/palette";
@@ -7,6 +7,7 @@ import Icon from "components/Icon";
 import IconWithTooltip from "components/IconWithTooltip";
 import TextInputWithGlyph from "components/TextInputWithGlyph";
 import { zIndex } from "constants/tokens";
+import { useKeyboardShortcut } from "hooks";
 
 const { yellow } = palette;
 interface SearchBarProps {
@@ -26,6 +27,23 @@ const SearchBar: React.FC<SearchBarProps> = ({
 }) => {
   const [input, setInput] = useState("");
   const [selected, setSelected] = useState("search");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useKeyboardShortcut(
+    ["Control", "f"],
+    () => {
+      if (inputRef.current) inputRef.current.focus();
+    },
+    disabled
+  );
+
+  useKeyboardShortcut(
+    ["Control", "s"],
+    () =>
+      selected === "search" ? setSelected("filter") : setSelected("search"),
+    disabled,
+    { overrideIgnore: true }
+  );
 
   const isValid = validator(input);
 
@@ -63,6 +81,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
             <IconButton
               aria-label="Select plus button"
               data-cy="searchbar-submit"
+              disabled={disabled || input.length === 0}
               onClick={handleOnSubmit}
             >
               <Icon glyph="Plus" />
@@ -77,6 +96,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
             </IconWithTooltip>
           )
         }
+        inputRef={inputRef}
         onChange={(e) => setInput(e.target.value)}
         onKeyPress={(e: KeyboardEvent<HTMLInputElement>) =>
           e.key === "Enter" && handleOnSubmit()

--- a/src/components/TextInputWithGlyph/index.tsx
+++ b/src/components/TextInputWithGlyph/index.tsx
@@ -4,14 +4,15 @@ import { size } from "constants/tokens";
 
 type TextInputWithGlyphProps = {
   icon: React.ReactElement;
+  inputRef?: React.RefObject<HTMLInputElement>;
 } & React.ComponentProps<typeof TextInput>;
 
 const TextInputWithGlyph: React.FC<TextInputWithGlyphProps> = (props) => {
-  const { icon, ...rest } = props;
+  const { icon, inputRef, ...rest } = props;
 
   return (
     <TextInputWrapper>
-      <TextInput {...rest} />
+      <TextInput ref={inputRef} {...rest} />
       <IconWrapper>{icon}</IconWrapper>
     </TextInputWrapper>
   );

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 import { useAxiosGet } from "./useAxios";
+import useKeyboardShortcut from "./useKeyboardShortcut";
 import useOnClickOutside from "./useOnClickOutside";
 
-export { useOnClickOutside, useAxiosGet };
+export { useOnClickOutside, useAxiosGet, useKeyboardShortcut };

--- a/src/hooks/useKeyboardShortcut/index.ts
+++ b/src/hooks/useKeyboardShortcut/index.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useRef } from "react";
+
+type UseKeyboardShortcutOptions = {
+  preventDefault?: boolean;
+  overrideIgnore?: boolean;
+};
+
+// Used to prevent shortcuts from being activated on input elements.
+const INPUT_ELEMENTS = ["INPUT", "TEXTAREA", "SELECT"];
+
+const useKeyboardShortcut = (
+  shortcutKeys: string[],
+  cb: () => void,
+  disabled: boolean = false,
+  options: UseKeyboardShortcutOptions = {}
+) => {
+  // We wrap the callback to prevent triggering unnecessary useEffect.
+  const cbRef = useRef(cb);
+  cbRef.current = cb;
+
+  const isShortcutPressed = useCallback(
+    (event: KeyboardEvent) => {
+      if (
+        shortcutKeys.includes("Control") &&
+        !event.ctrlKey &&
+        !event.metaKey
+      ) {
+        return false;
+      }
+      if (shortcutKeys.includes("Shift") && !event.shiftKey) return false;
+      if (shortcutKeys.includes("Alt") && !event.altKey) return false;
+      return shortcutKeys[shortcutKeys.length - 1] === event.key;
+    },
+    [shortcutKeys]
+  );
+
+  const handleKeydown = useCallback(
+    (event: KeyboardEvent) => {
+      const { preventDefault = true, overrideIgnore = false } = options;
+
+      const shortcutPressed = isShortcutPressed(event);
+      const shouldIgnore =
+        !overrideIgnore &&
+        INPUT_ELEMENTS.includes((event.target as HTMLElement).tagName);
+
+      if (shortcutPressed) {
+        // Prevent browser default behavior.
+        if (preventDefault) {
+          event.preventDefault();
+        }
+        if (!shouldIgnore) {
+          cbRef.current();
+        }
+      }
+    },
+    [isShortcutPressed, options]
+  );
+
+  useEffect(() => {
+    // There's no need to keep track of events if the component is disabled.
+    if (disabled) {
+      document.removeEventListener("keydown", handleKeydown);
+    } else {
+      document.addEventListener("keydown", handleKeydown);
+    }
+
+    return (): void => {
+      document.removeEventListener("keydown", handleKeydown);
+    };
+  }, [handleKeydown, disabled]);
+};
+
+export default useKeyboardShortcut;

--- a/src/hooks/useKeyboardShortcut/useKeyboardShortcut.test.tsx
+++ b/src/hooks/useKeyboardShortcut/useKeyboardShortcut.test.tsx
@@ -1,0 +1,74 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { render, screen, userEvent } from "test_utils";
+import useKeyboardShortcut from ".";
+
+describe("useKeyboardShortcut", () => {
+  const user = userEvent.setup();
+
+  it("should call the callback when the specified shortcut keys are pressed", async () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut(["Control", "a"], callback));
+
+    await user.keyboard("{Control}");
+    expect(callback).toHaveBeenCalledTimes(0);
+    await user.keyboard("{a}");
+    expect(callback).toHaveBeenCalledTimes(0);
+    await user.keyboard("{Control>}{a}");
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not call the callback if an input element has focus", async () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut(["Control", "a"], callback));
+    render(<input data-cy="test-input" />);
+
+    await user.click(screen.getByDataCy("test-input"));
+    expect(screen.getByDataCy("test-input")).toHaveFocus();
+    await user.keyboard("{Control>}{a}");
+    expect(callback).toHaveBeenCalledTimes(0);
+  });
+
+  it("should call the callback if an input element has focus and overrideIgnore is enabled", async () => {
+    const callback = jest.fn();
+    renderHook(() =>
+      useKeyboardShortcut(["Control", "a"], callback, false, {
+        overrideIgnore: true,
+      })
+    );
+    render(<input data-cy="test-input" />);
+
+    await user.click(screen.getByDataCy("test-input"));
+    expect(screen.getByDataCy("test-input")).toHaveFocus();
+    await user.keyboard("{Control>}{a}");
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not call the callback if the component is disabled", async () => {
+    const callback = jest.fn();
+    const disabled = true;
+    renderHook(() => useKeyboardShortcut(["Control", "a"], callback, disabled));
+    await user.keyboard("{a}");
+    expect(callback).toHaveBeenCalledTimes(0);
+  });
+
+  it("should remove the event listener if the component is initially enabled, then disabled", async () => {
+    const mockedAddEventListener = jest.fn();
+    const mockedRemoveEventListener = jest.fn();
+    jest
+      .spyOn(document, "addEventListener")
+      .mockImplementation(mockedAddEventListener);
+    jest
+      .spyOn(document, "removeEventListener")
+      .mockImplementation(mockedRemoveEventListener);
+
+    const { rerender: rerenderHook } = renderHook(
+      (args: { disabled: boolean } = { disabled: false }) =>
+        useKeyboardShortcut(["a"], jest.fn(), args.disabled)
+    );
+    expect(mockedAddEventListener).toHaveBeenCalledTimes(1);
+
+    rerenderHook({ disabled: true });
+    expect(mockedAddEventListener).toHaveBeenCalledTimes(1);
+    expect(mockedRemoveEventListener).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
EVG-17622

### Description 
This PR adds a hook called `useKeyboardShortcut` which can be used to register shortcuts with individual components. 

In the code you'll see that I conflated the `Control` key with the `Meta` key; that is because Windows users use the `Control` key to execute keyboard commands, while Mac users use the `Command/Meta` key to execute keyboard commands.

As an example I added the following keyboard shortcuts:
- `Ctrl + F`: Puts focus on the searchbar input.
- `Ctrl + D`: Opens and closes the filters drawer. Is not activated when there is focus on the searchbar input.
- `Ctrl + S`: Switches between the Search/Filter mode. Is activated when there is focus on the searchbar input.

### Screenshots
TODO

### Testing 
- Added tests in `useKeyboardShortcut.test.ts`
- Added a test in `SearchBar.test.tsx`
