### PR TITLE
EVG-18081 Sanitize html characters for resmoke lines

### DIFF
--- a/src/components/LogRow/BaseRow/index.tsx
+++ b/src/components/LogRow/BaseRow/index.tsx
@@ -8,6 +8,7 @@ import { QueryParams } from "constants/queryParams";
 import { fontSize, size } from "constants/tokens";
 import { useQueryParam } from "hooks/useQueryParam";
 import renderHtml from "utils/renderHtml";
+import { escapeHtml } from "utils/renderHtml/escapeHtml";
 
 const { yellow, red } = palette;
 
@@ -121,7 +122,11 @@ const ProcessedBaseRow: React.FC<ProcessedBaseRowProps> = memo((props) => {
   const memoizedLogLine = useMemo(() => {
     let render = children;
     if (searchTerm) {
-      render = render.replace(searchTerm, `<mark>$&</mark>`);
+      // escape the matching string to prevent XSS
+      render = render.replace(
+        searchTerm,
+        (match) => `<mark>${escapeHtml(match)}</mark>`
+      );
     }
     return renderHtml(render, {
       transform: {

--- a/src/components/LogRow/ResmokeRow/index.tsx
+++ b/src/components/LogRow/ResmokeRow/index.tsx
@@ -2,6 +2,7 @@ import { forwardRef } from "react";
 import CollapsedRow from "components/LogRow//CollapsedRow";
 import BaseRow from "components/LogRow/BaseRow";
 import { isCollapsedRow } from "utils/collapsedRow";
+import { escapeHtml } from "utils/renderHtml/escapeHtml";
 import { BaseRowProps } from "../types";
 import { isLineInRange } from "../utils";
 
@@ -26,7 +27,7 @@ const ResmokeRow = forwardRef<any, BaseRowProps>((rowProps, ref) => {
       <CollapsedRow ref={ref} {...listRowProps} numCollapsed={line.length} />
     );
   }
-  const lineContent = getLine(line);
+  const lineContent = escapeHtml(getLine(line) || "");
   const color = getResmokeLineColor(line);
   const inRange = isLineInRange(range, line);
 

--- a/src/components/LogRow/ResmokeRow/index.tsx
+++ b/src/components/LogRow/ResmokeRow/index.tsx
@@ -2,7 +2,6 @@ import { forwardRef } from "react";
 import CollapsedRow from "components/LogRow//CollapsedRow";
 import BaseRow from "components/LogRow/BaseRow";
 import { isCollapsedRow } from "utils/collapsedRow";
-import { escapeHtml } from "utils/renderHtml/escapeHtml";
 import { BaseRowProps } from "../types";
 import { isLineInRange } from "../utils";
 
@@ -27,7 +26,7 @@ const ResmokeRow = forwardRef<any, BaseRowProps>((rowProps, ref) => {
       <CollapsedRow ref={ref} {...listRowProps} numCollapsed={line.length} />
     );
   }
-  const lineContent = escapeHtml(getLine(line) || "");
+  const lineContent = getLine(line) || "";
   const color = getResmokeLineColor(line);
   const inRange = isLineInRange(range, line);
 

--- a/src/utils/renderHtml/escapeHtml.ts
+++ b/src/utils/renderHtml/escapeHtml.ts
@@ -1,0 +1,9 @@
+const escapeHtml = (html: string) =>
+  html
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+
+export { escapeHtml };

--- a/src/utils/renderHtml/index.tsx
+++ b/src/utils/renderHtml/index.tsx
@@ -26,10 +26,15 @@ interface renderHtmlOptions extends HTMLReactParserOptions {
     [key: string]: React.ReactNode;
   };
 }
+
+const allowedTags = ["a", "span", "mark"];
 const renderHtml = (html: string = "", options: renderHtmlOptions = {}) =>
   parse(html, {
     replace: (domNode) => {
       if (domNode instanceof Element) {
+        if (!allowedTags.includes(domNode.name)) {
+          return <>&lt;{domNode.tagName}&gt;</>;
+        }
         if (options.transform && options.transform[domNode.name]) {
           const SwapComponent = options.transform[domNode.name];
           // SwapComponent is just what ever component we want to return from the transform object

--- a/src/utils/renderHtml/renderHtml.test.tsx
+++ b/src/utils/renderHtml/renderHtml.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "test_utils";
 import renderHtml from ".";
+import { escapeHtml } from "./escapeHtml";
 
 describe("renderHtml", () => {
   it("renders a plain string with no html", () => {
@@ -25,5 +26,15 @@ describe("renderHtml", () => {
     expect(screen.queryByDataCy("element")).not.toBeInTheDocument();
     expect(screen.getByDataCy("component")).toBeInTheDocument();
     expect(screen.queryByDataCy("component")).toHaveTextContent("✨string✨");
+  });
+});
+
+describe("escapeHtml", () => {
+  it("escapes html", () => {
+    expect(escapeHtml("<div>")).toBe("&lt;div&gt;");
+    expect(escapeHtml("<span>some text</span>")).toBe(
+      "&lt;span&gt;some text&lt;/span&gt;"
+    );
+    expect(escapeHtml("<preview>")).toBe("&lt;preview&gt;");
   });
 });


### PR DESCRIPTION
EVG-18081

### Description 
Some resmoke lines often contain strings that resemble html characters. This is problematic when they are run through `parseHtml` since it will try to transform the string into an html element which does not exist. This PR adds a function called `escapeHtml`  which will replace any special characters with the ansii string representation. 

Added an allowlist to `parseHtml` i only enabled the tags we would expect to see this can be updated in the future.


### Testing 
No more console errors
Unit tests
