### PR TITLE
EVG-17545 Use Parsley URL when uploading source maps

### DIFF
--- a/scripts/upload-bugsnag-sourcemaps.js
+++ b/scripts/upload-bugsnag-sourcemaps.js
@@ -5,5 +5,5 @@ browser.uploadMultiple({
   appVersion: process.env.REACT_APP_VERSION,
   overwrite: true,
   directory: "./dist/assets",
-  baseUrl: `${process.env.REACT_APP_SPRUCE_URL}/assets`,
+  baseUrl: `${process.env.REACT_APP_PARSLEY_URL}/assets`,
 });


### PR DESCRIPTION
EVG-17545

### Description 
Accidentally uploaded source maps and set the spruce url as the base instead of parsley

