### PR TITLE
EVG-18085: Fix favicon path

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="ui-version" content="%GIT_SHA%">
-  <link rel="shortcut icon" href="/public/favicon.ico" />
+  <link rel="shortcut icon" href="/favicon.ico" />
   <title>Parsley</title>
 </head>
 

--- a/src/pages/LogDrop/FileDropper.tsx
+++ b/src/pages/LogDrop/FileDropper.tsx
@@ -12,7 +12,7 @@ import { useLogContext } from "context/LogContext";
 import { useToastContext } from "context/toast";
 import { leaveBreadcrumb } from "utils/errorReporting";
 
-const { red } = palette;
+const { green } = palette;
 interface FileDropperProps {
   onChangeLogType: (logType: LogTypes) => void;
 }
@@ -61,7 +61,7 @@ const FileDropper: React.FC<FileDropperProps> = ({ onChangeLogType }) => {
 
   return (
     <Container>
-      <RedBorderBox>
+      <BorderBox>
         {hasDroppedLog ? (
           <ProcessLogsContainer>
             <Select
@@ -102,7 +102,7 @@ const FileDropper: React.FC<FileDropperProps> = ({ onChangeLogType }) => {
             )}
           </UploadLogsContainer>
         )}
-      </RedBorderBox>
+      </BorderBox>
     </Container>
   );
 };
@@ -115,7 +115,7 @@ const Container = styled.div`
   height: 100%;
 `;
 
-const RedBorderBox = styled.div`
+const BorderBox = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -123,7 +123,7 @@ const RedBorderBox = styled.div`
   height: 30vh;
 
   padding: ${size.xl};
-  border: ${size.xxs} dashed ${red.base};
+  border: ${size.xxs} dashed ${green.base};
   border-radius: ${size.s};
 `;
 


### PR DESCRIPTION
EVG-18085

### Description 
Since `vite.config.ts` sets the `publicDir` to `<root>/public` by default, we don't need to include public in the path to the favicon. If you can't see the favicon in your browser after pulling this change, you probably need to hard refresh the tab.

### Screenshots
Also I made this green

<img width="1556" alt="Screen Shot 2022-10-28 at 11 53 42 AM" src="https://user-images.githubusercontent.com/47064971/198683792-8d797d2a-4f36-42ca-a278-d80cfa838701.png">

### Testing 
- I just looked at it 😳

