### PR TITLE
EVG-18195: Fix duplicate scrollbar issue

### DIFF
--- a/cypress/integration/ansiiLogs/ansii_logView.ts
+++ b/cypress/integration/ansiiLogs/ansii_logView.ts
@@ -20,8 +20,8 @@ describe("Basic evergreen log view", () => {
     cy.dataCy("log-row-22").isNotContainedInViewport();
     cy.get(".ReactVirtualized__Grid__innerScrollContainer").should(
       "have.css",
-      "overflow",
-      "scroll auto"
+      "overflow-x",
+      "scroll"
     );
   });
   it("long lines with wrapping turned on should fit on screen", () => {

--- a/cypress/integration/resmokeLogs/resmoke_logView.ts
+++ b/cypress/integration/resmokeLogs/resmoke_logView.ts
@@ -15,8 +15,8 @@ describe("Basic resmoke log view", () => {
     cy.dataCy("log-row-16").isNotContainedInViewport();
     cy.get(".ReactVirtualized__Grid__innerScrollContainer").should(
       "have.css",
-      "overflow",
-      "scroll auto"
+      "overflow-x",
+      "scroll"
     );
   });
   it("long lines with wrapping turned on should fit on screen", () => {

--- a/src/components/LogPane/index.tsx
+++ b/src/components/LogPane/index.tsx
@@ -28,14 +28,24 @@ const LogPane: React.FC<LogPaneProps> = ({
   wrap,
   ...rest
 }) => {
-  const { listRef, matchingLines, prettyPrint } = useLogContext();
+  const { listRef, expandedLines, matchingLines, prettyPrint } =
+    useLogContext();
 
   const [expandableRows] = useQueryParam(QueryParams.Expandable, true);
+  const stringifiedExpandedLines = expandedLines.toString();
 
   useEffect(() => {
     cache.clearAll();
     listRef.current?.recomputeRowHeights();
-  }, [listRef, cache, wrap, matchingLines, expandableRows, prettyPrint]);
+  }, [
+    listRef,
+    cache,
+    expandableRows,
+    matchingLines,
+    prettyPrint,
+    stringifiedExpandedLines,
+    wrap,
+  ]);
 
   return (
     <AutoSizer>
@@ -43,7 +53,7 @@ const LogPane: React.FC<LogPaneProps> = ({
         <List
           ref={listRef}
           cache={cache}
-          containerStyle={{ overflow: "scroll visible" }}
+          containerStyle={{ overflowX: "scroll" }}
           deferredMeasurementCache={cache}
           height={height}
           overscanRowCount={200}

--- a/src/components/LogPane/index.tsx
+++ b/src/components/LogPane/index.tsx
@@ -28,24 +28,14 @@ const LogPane: React.FC<LogPaneProps> = ({
   wrap,
   ...rest
 }) => {
-  const { listRef, expandedLines, matchingLines, prettyPrint } =
-    useLogContext();
+  const { listRef, matchingLines, prettyPrint } = useLogContext();
 
   const [expandableRows] = useQueryParam(QueryParams.Expandable, true);
-  const stringifiedExpandedLines = expandedLines.toString();
 
   useEffect(() => {
     cache.clearAll();
     listRef.current?.recomputeRowHeights();
-  }, [
-    listRef,
-    cache,
-    expandableRows,
-    matchingLines,
-    prettyPrint,
-    stringifiedExpandedLines,
-    wrap,
-  ]);
+  }, [listRef, cache, wrap, matchingLines, expandableRows, prettyPrint]);
 
   return (
     <AutoSizer>

--- a/src/components/LogRow/CollapsedRow/CollapsedRow.stories.tsx
+++ b/src/components/LogRow/CollapsedRow/CollapsedRow.stories.tsx
@@ -4,6 +4,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import LogPane from "components/LogPane";
 import { RowRenderer, cache } from "components/LogRow/RowRenderer";
 import { LogTypes } from "constants/enums";
+import { useLogContext } from "context/LogContext";
 import CollapsedRow from ".";
 
 export default {
@@ -21,6 +22,13 @@ const CollapsedAnsiiTemplate: ComponentStory<CollapsedRowProps> = (args) => {
   const [processedLogLines, setProcessedLogLines] = useState(
     collapsedProcessedLogLines
   );
+  const { listRef } = useLogContext();
+
+  const onExpand = () => {
+    setProcessedLogLines([0, 1, 2, 3, 4, 5, 6, 7]);
+    cache.clearAll();
+    listRef.current?.recomputeRowHeights();
+  };
 
   return (
     <Container>
@@ -31,7 +39,7 @@ const CollapsedAnsiiTemplate: ComponentStory<CollapsedRowProps> = (args) => {
         rowCount={processedLogLines.length}
         rowRenderer={RowRenderer({
           data: {
-            expandLines: () => setProcessedLogLines([0, 1, 2, 3, 4, 5, 6, 7]),
+            expandLines: onExpand,
             getLine: (index: number) => ansiiLogLines[index],
             getResmokeLineColor: () => undefined,
             resetRowHeightAtIndex: () => undefined,
@@ -66,6 +74,14 @@ const CollapsedResmokeTemplate: ComponentStory<CollapsedRowProps> = (args) => {
     collapsedProcessedLogLines
   );
 
+  const { listRef } = useLogContext();
+
+  const onExpand = () => {
+    setProcessedLogLines([0, 1, 2, 3, 4, 5, 6, 7]);
+    cache.clearAll();
+    listRef.current?.recomputeRowHeights();
+  };
+
   return (
     <Container>
       <LogPane
@@ -75,7 +91,7 @@ const CollapsedResmokeTemplate: ComponentStory<CollapsedRowProps> = (args) => {
         rowCount={processedLogLines.length}
         rowRenderer={RowRenderer({
           data: {
-            expandLines: () => setProcessedLogLines([0, 1, 2, 3, 4, 5, 6, 7]),
+            expandLines: onExpand,
             getLine: (index: number) => resmokeLogLines[index],
             getResmokeLineColor: () => undefined,
             resetRowHeightAtIndex: () => undefined,

--- a/src/context/LogContext/index.tsx
+++ b/src/context/LogContext/index.tsx
@@ -107,12 +107,7 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
   const matchingLines = useMemo(
     () => getMatchingLines(state.logs, filters, filterLogic),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      stringifiedFilters,
-      stringifiedExpandedLines,
-      state.logs.length,
-      filterLogic,
-    ]
+    [stringifiedFilters, state.logs.length, filterLogic]
   );
 
   useEffect(

--- a/src/context/LogContext/index.tsx
+++ b/src/context/LogContext/index.tsx
@@ -107,7 +107,12 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
   const matchingLines = useMemo(
     () => getMatchingLines(state.logs, filters, filterLogic),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [stringifiedFilters, state.logs.length, filterLogic]
+    [
+      stringifiedFilters,
+      stringifiedExpandedLines,
+      state.logs.length,
+      filterLogic,
+    ]
   );
 
   useEffect(


### PR DESCRIPTION
EVG-18195

### Description 
This PR removes the double scrollbar that was appearing in the `Y` direction. We were using `overflow` styling on the list container but we only really need `overflow-x` to enable horizontal scrolling.

Note that while there will no longer be two scrollbars, the scrollbars will still be visually different between mouse and trackpad. This is more a responsibility for the user, as they will need to change their scrolling settings to the following under General in System Preferences:

<img width="457" alt="Screen Shot 2022-11-01 at 2 53 01 PM" src="https://user-images.githubusercontent.com/47064971/199314759-a3725177-8a29-4aab-9996-99f4e71ff72a.png">

Perhaps we can put this in a FAQ somewhere, although it is a Mac specific setting.

### Screenshots
- N/A

### Testing
- Fixed stories which had been showing incorrect behavior when applying wrap and expanding rows.
- Update e2e tests