### PR TITLE
EVG-18315 Hide expandable rows instead of removing filters

### DIFF
--- a/src/utils/filterLogs/filterLogs.test.ts
+++ b/src/utils/filterLogs/filterLogs.test.ts
@@ -25,7 +25,7 @@ describe("filterLogs", () => {
     ).toStrictEqual([0, 1, 2, 3, 4, 5, 6, 7]);
   });
 
-  it("should return the log lines as is if expandable rows are turned off", () => {
+  it("should not return collapsed lines if expandedRows is turned off", () => {
     expect(
       filterLogs({
         logLines,
@@ -35,7 +35,7 @@ describe("filterLogs", () => {
         expandedLines: [],
         expandableRows: false,
       })
-    ).toStrictEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    ).toStrictEqual([1, 2, 3]);
   });
 
   it("should collapse all of the log lines if there are no matching lines", () => {

--- a/src/utils/filterLogs/filterLogs.test.ts
+++ b/src/utils/filterLogs/filterLogs.test.ts
@@ -25,7 +25,7 @@ describe("filterLogs", () => {
     ).toStrictEqual([0, 1, 2, 3, 4, 5, 6, 7]);
   });
 
-  it("should not return collapsed lines if expandedRows is turned off", () => {
+  it("should hide collapsed rows if expandableRows is turned off", () => {
     expect(
       filterLogs({
         logLines,

--- a/src/utils/filterLogs/index.ts
+++ b/src/utils/filterLogs/index.ts
@@ -32,7 +32,7 @@ const filterLogs = ({
 }: FilterLogsParams): (number | number[])[] => {
   // If there are no filters or expandable rows is not enabled, then we don't have to do any
   // processing.
-  if (matchingLines === undefined || !expandableRows) {
+  if (matchingLines === undefined) {
     return logLines.map((_, idx) => idx);
   }
 
@@ -55,12 +55,14 @@ const filterLogs = ({
       return arr;
     }
 
-    // If the line doesn't match the filters, collapse it.
-    const previousItem = arr[arr.length - 1];
-    if (isCollapsedRow(previousItem)) {
-      previousItem.push(idx);
-    } else {
-      arr.push([idx]);
+    if (expandableRows) {
+      // If the line doesn't match the filters, collapse it.
+      const previousItem = arr[arr.length - 1];
+      if (isCollapsedRow(previousItem)) {
+        previousItem.push(idx);
+      } else {
+        arr.push([idx]);
+      }
     }
     return arr;
   }, filteredLines);


### PR DESCRIPTION
EVG-18315

### Description 
Expandable Rows should just hide the buttons instead of disabling filtering.
