### PR TITLE
EVG-18358 Report errors when fetching logs

### DIFF
--- a/src/hooks/useFetch/index.ts
+++ b/src/hooks/useFetch/index.ts
@@ -35,7 +35,7 @@ const useFetch = <T extends object>(
       })
         .then((response) => {
           if (!response.ok) {
-            throw new Error(`while making request: ${response.status}`);
+            throw new Error(`making request: ${response.status}`);
           }
           return response;
         })

--- a/src/hooks/useFetch/index.ts
+++ b/src/hooks/useFetch/index.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { isProduction } from "utils/environmentVariables";
-import { leaveBreadcrumb } from "utils/errorReporting";
+import { leaveBreadcrumb, reportError } from "utils/errorReporting";
 /**
  * `useFetch` is a custom hook that downloads json from a given URL.
  * It returns an object with the following properties:
@@ -35,7 +35,7 @@ const useFetch = <T extends object>(
       })
         .then((response) => {
           if (!response.ok) {
-            throw new Error(response.statusText);
+            throw new Error(`while making request: ${response.status}`);
           }
           return response;
         })
@@ -45,6 +45,7 @@ const useFetch = <T extends object>(
         })
         .catch((err: Error) => {
           leaveBreadcrumb("useFetch", { url, err }, "error");
+          reportError(err).severe();
           setError(err.message);
         })
         .finally(() => {

--- a/src/hooks/useLogDownloader/index.ts
+++ b/src/hooks/useLogDownloader/index.ts
@@ -28,7 +28,7 @@ const useLogDownloader = (url: string) => {
     })
       .then((response) => {
         if (!response.ok) {
-          throw new Error(`While downloading log: ${response.status}`);
+          throw new Error(`downloading log: ${response.status}`);
         }
         return response;
       })

--- a/src/hooks/useLogDownloader/index.ts
+++ b/src/hooks/useLogDownloader/index.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { isProduction } from "utils/environmentVariables";
-import { leaveBreadcrumb } from "utils/errorReporting";
+import { leaveBreadcrumb, reportError } from "utils/errorReporting";
 /**
  * `useLogDownloader` is a custom hook that downloads a log file from a given URL.
  * It downloads the log file and splits the log file into an array of strings.
@@ -28,7 +28,7 @@ const useLogDownloader = (url: string) => {
     })
       .then((response) => {
         if (!response.ok) {
-          throw new Error(response.statusText);
+          throw new Error(`While downloading log: ${response.status}`);
         }
         return response;
       })
@@ -38,6 +38,7 @@ const useLogDownloader = (url: string) => {
       })
       .catch((err: Error) => {
         leaveBreadcrumb("useLogDownloader", { url, err }, "error");
+        reportError(err).severe();
         setError(err.message);
       })
       .finally(() => {


### PR DESCRIPTION
EVG-18358

### Description 
 Since we are awesome and handle the errors while fetching bugsnag doesn't automatically report the errors. So this adds some reporting. 
### Screenshots
<img width="1234" alt="image" src="https://user-images.githubusercontent.com/4605522/204920155-feba5042-2479-4acc-b714-21668539f494.png">

### Testing 
Broke some stuff

