### PR TITLE
EVG-18441 Handle timestamps with negative offsets

### DIFF
--- a/src/utils/resmoke/helpers.test.ts
+++ b/src/utils/resmoke/helpers.test.ts
@@ -181,6 +181,14 @@ describe("resmoke/helpers", () => {
         getTimeStamp(`{"t":{"$date":"2022-09-13T16:57:46.852+00:00"}`)
       ).toBe("2022-09-13T16:57:46.852+00:00");
     });
+    it("handles strings with offset timestamps", () => {
+      expect(
+        getTimeStamp(`{"t":{"$date":"2022-09-13T16:57:46.852+00:00"}`)
+      ).toBe("2022-09-13T16:57:46.852+00:00");
+      expect(
+        getTimeStamp(`{"t":{"$date":"2022-09-13T16:57:46.852-00:00"}`)
+      ).toBe("2022-09-13T16:57:46.852-00:00");
+    });
   });
   describe("getState", () => {
     it("correctly returns state", () => {

--- a/src/utils/resmoke/helpers.ts
+++ b/src/utils/resmoke/helpers.ts
@@ -65,8 +65,9 @@ const timeStampRegex =
  * @example "t":{"$date":"2021-03-03T20:54:54.000-0400"}
  * @example "t":{"$date":"2021-03-03T20:54:54.000+0400"}
  */
+
 const timestampWithOffsetRegex =
-  /{"t":{"\$date":"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+\d{2}:\d{2})"}/;
+  /{"t":{"\$date":"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2})"}/;
 
 /** `getTimeStamp` returns the timestamp ran by a resmoke function this is found in the resmoke json  */
 const getTimeStamp = (line: string) => {


### PR DESCRIPTION
EVG-18441

### Description 
Some logs featured negative timestamps which would not be detected by our regex this updates the offset regex to support it. 
### Screenshots
Before:
<img width="705" alt="image" src="https://user-images.githubusercontent.com/4605522/205367310-56aa55b6-323b-4805-93eb-5d03f8a67ac8.png">
After:
<img width="1400" alt="image" src="https://user-images.githubusercontent.com/4605522/205367437-a493def4-e3c2-4d6a-8c32-40606f35d8d3.png">

