### PR TITLE
EVG-18375: Render rows that contain empty strings

### DIFF
--- a/src/components/LogRow/AnsiiRow/AnsiiRow.test.tsx
+++ b/src/components/LogRow/AnsiiRow/AnsiiRow.test.tsx
@@ -11,6 +11,40 @@ const wrapper = (logs: string[]) => {
 
 describe("ansiiRow", () => {
   const user = userEvent.setup();
+  it("does not render an ansii row if getLine returns undefined", () => {
+    const getLine = jest.fn().mockReturnValue(undefined);
+    renderWithRouterMatch(
+      <AnsiiRow
+        data={{
+          ...data,
+          getLine,
+        }}
+        lineNumber={0}
+        listRowProps={listRowProps}
+      />,
+      {
+        wrapper: wrapper(logLines),
+      }
+    );
+    expect(screen.queryByDataCy("ansii-row")).toBeNull();
+  });
+  it("renders an ansii row if getLine returns an empty string", () => {
+    const getLine = jest.fn().mockReturnValue("");
+    renderWithRouterMatch(
+      <AnsiiRow
+        data={{
+          ...data,
+          getLine,
+        }}
+        lineNumber={0}
+        listRowProps={listRowProps}
+      />,
+      {
+        wrapper: wrapper(logLines),
+      }
+    );
+    expect(screen.getByDataCy("ansii-row")).toBeInTheDocument();
+  });
   it("displays a log line and its text for a given index", () => {
     renderWithRouterMatch(
       <AnsiiRow data={data} lineNumber={0} listRowProps={listRowProps} />,

--- a/src/components/LogRow/AnsiiRow/index.tsx
+++ b/src/components/LogRow/AnsiiRow/index.tsx
@@ -24,15 +24,15 @@ const AnsiiRow = forwardRef<any, AnsiiRowProps>((rowProps, ref) => {
     highlights,
   } = data;
 
-  const lineContent = getLine(lineNumber) || "";
-  const linkifiedLine = linkifyHtml(ansiUp.ansi_to_html(lineContent), {
+  const lineContent = getLine(lineNumber);
+  const linkifiedLine = linkifyHtml(ansiUp.ansi_to_html(lineContent ?? ""), {
     validate: {
       url: (value: string) => /^(http)s?:\/\//.test(value),
     },
   });
   const inRange = isLineInRange(range, lineNumber);
 
-  return lineContent ? (
+  return lineContent !== undefined ? (
     <BaseRow
       {...listRowProps}
       ref={ref}

--- a/src/components/LogRow/ResmokeRow/ResmokeRow.test.tsx
+++ b/src/components/LogRow/ResmokeRow/ResmokeRow.test.tsx
@@ -11,6 +11,40 @@ const wrapper = (logs: string[]) => {
 
 describe("resmokeRow", () => {
   const user = userEvent.setup();
+  it("does not render a resmoke row if getLine returns undefined", () => {
+    const getLine = jest.fn().mockReturnValue(undefined);
+    renderWithRouterMatch(
+      <ResmokeRow
+        data={{
+          ...data,
+          getLine,
+        }}
+        lineNumber={0}
+        listRowProps={listRowProps}
+      />,
+      {
+        wrapper: wrapper(logLines),
+      }
+    );
+    expect(screen.queryByDataCy("resmoke-row")).toBeNull();
+  });
+  it("renders a resmoke row if getLine returns an empty string", () => {
+    const getLine = jest.fn().mockReturnValue("");
+    renderWithRouterMatch(
+      <ResmokeRow
+        data={{
+          ...data,
+          getLine,
+        }}
+        lineNumber={0}
+        listRowProps={listRowProps}
+      />,
+      {
+        wrapper: wrapper(logLines),
+      }
+    );
+    expect(screen.getByDataCy("resmoke-row")).toBeInTheDocument();
+  });
   it("displays a log line and its text for a given index", () => {
     renderWithRouterMatch(
       <ResmokeRow data={data} lineNumber={0} listRowProps={listRowProps} />,

--- a/src/components/LogRow/ResmokeRow/index.tsx
+++ b/src/components/LogRow/ResmokeRow/index.tsx
@@ -26,7 +26,7 @@ const ResmokeRow = forwardRef<any, ResmokeRowProps>((rowProps, ref) => {
   const lineColor = getResmokeLineColor(lineNumber);
   const inRange = isLineInRange(range, lineNumber);
 
-  return lineContent ? (
+  return lineContent !== undefined ? (
     <BaseRow
       {...listRowProps}
       ref={ref}


### PR DESCRIPTION
EVG-18375

### Description 
This PR makes it so that we render rows that contain empty strings. The reason they were not being rendered before is because we were only checking if `lineContent` is falsy.

#### Ideas
Maybe we can introduce an option when parsing the log to omit lines that only contain empty strings? We would need to know if users would actually find this helpful though.

### Screenshots
<img width="634" alt="Screen Shot 2022-12-06 at 11 11 59 AM" src="https://user-images.githubusercontent.com/47064971/205970673-4a54c0ff-e7ce-4be1-af63-c3c411fa4471.png">


### Testing 
- Added tests in `ResmokeRow.test.tsx`
- Added tests in `AnsiiRow.test.tsx`

