### PR TITLE
EVG-18447 Fix logic to sanitize html to handle incomplete tags.

### DIFF
--- a/src/components/LogRow/BaseRow/Row.test.tsx
+++ b/src/components/LogRow/BaseRow/Row.test.tsx
@@ -7,6 +7,12 @@ describe("row", () => {
     expect(screen.getByText(testLog)).toBeVisible();
   });
 
+  it("properly escapes a log line with tags and renders its contents", () => {
+    const lineContent = `Test line with a <nil> value`;
+    renderWithRouterMatch(<Row {...rowProps}>{lineContent}</Row>);
+    expect(screen.getByText(lineContent)).toBeVisible();
+  });
+
   it("clicking log line link updates the url and and scrolls to the line", async () => {
     const scrollToLine = jest.fn();
     const { history } = renderWithRouterMatch(

--- a/src/utils/renderHtml/escapeHtml.ts
+++ b/src/utils/renderHtml/escapeHtml.ts
@@ -1,3 +1,8 @@
+/**
+ * `escapeHtml` escapes HTML special characters in a string.
+ * @param html - The html string to escape
+ * @returns  The escaped html string
+ */
 const escapeHtml = (html: string) =>
   html
     .replace(/&/g, "&amp;")

--- a/src/utils/renderHtml/index.tsx
+++ b/src/utils/renderHtml/index.tsx
@@ -3,7 +3,7 @@ import parse, {
   HTMLReactParserOptions,
   domToReact,
 } from "html-react-parser";
-
+import { sanitizeHtml } from "./sanitizeHtml";
 /**
  * renderHtml takes a string and converts it into an array of domnodes and
  * parses through them and swaps elements with other elements based on if they are
@@ -28,13 +28,12 @@ interface renderHtmlOptions extends HTMLReactParserOptions {
 }
 
 const allowedTags = ["a", "span", "mark"];
-const renderHtml = (html: string = "", options: renderHtmlOptions = {}) =>
-  parse(html, {
+const renderHtml = (html: string = "", options: renderHtmlOptions = {}) => {
+  const sanitizedHtml = sanitizeHtml(html, allowedTags);
+
+  return parse(sanitizedHtml, {
     replace: (domNode) => {
       if (domNode instanceof Element) {
-        if (!allowedTags.includes(domNode.name)) {
-          return <>&lt;{domNode.tagName}&gt;</>;
-        }
         if (options.transform && options.transform[domNode.name]) {
           const SwapComponent = options.transform[domNode.name];
           // SwapComponent is just what ever component we want to return from the transform object
@@ -54,4 +53,6 @@ const renderHtml = (html: string = "", options: renderHtmlOptions = {}) =>
       }
     },
   });
+};
+
 export default renderHtml;

--- a/src/utils/renderHtml/renderHtml.test.tsx
+++ b/src/utils/renderHtml/renderHtml.test.tsx
@@ -1,16 +1,31 @@
 import { render, screen } from "test_utils";
 import renderHtml from ".";
 import { escapeHtml } from "./escapeHtml";
+import { sanitizeHtml } from "./sanitizeHtml";
 
 describe("renderHtml", () => {
   it("renders a plain string with no html", () => {
     render(<>{renderHtml("test string")}</>);
     expect(screen.getByText("test string")).toBeInTheDocument();
   });
-  it("renders a string with html", () => {
+  it("renders a string with html and preserves allowed elements with their props", () => {
     render(<>{renderHtml("test <span data-cy='element'>string</span>")}</>);
     expect(screen.queryByDataCy("element")).toHaveTextContent("string");
   });
+  it("renders a string with html and escapes disallowed elements", () => {
+    render(
+      <>
+        {renderHtml(
+          "<span data-cy='log-line'>test <script data-cy='should-not-exist'>alert('test')</script></span>"
+        )}
+      </>
+    );
+    expect(screen.queryByDataCy("should-not-exist")).toBeNull();
+    expect(screen.queryByDataCy("log-line")).toHaveTextContent(
+      "test <script data-cy='should-not-exist'>alert('test')</script>"
+    );
+  });
+
   it("replaces a element with a react component if specified", () => {
     const Component = ({ children }: { children: React.ReactElement }) => (
       <div data-cy="component">✨{children}✨</div>
@@ -36,5 +51,24 @@ describe("escapeHtml", () => {
       "&lt;span&gt;some text&lt;/span&gt;"
     );
     expect(escapeHtml("<preview>")).toBe("&lt;preview&gt;");
+    expect(escapeHtml(`some "string"`)).toBe("some &quot;string&quot;");
+  });
+});
+
+describe("sanitizeHtml", () => {
+  it("sanitizes html tags", () => {
+    expect(sanitizeHtml("<nav>", [])).toBe("&lt;nav&gt;");
+    expect(sanitizeHtml("<span>some text</span>", ["span"])).toBe(
+      "<span>some text</span>"
+    );
+    expect(
+      sanitizeHtml("<span withProps='test'>some text</span>", ["span"])
+    ).toBe("<span withProps='test'>some text</span>");
+    expect(
+      sanitizeHtml("<div withProps='test'>some text</div>", ["span"])
+    ).toBe("&lt;div withProps='test'&gt;some text&lt;/div&gt;");
+    expect(sanitizeHtml("<script>alert('some alert')</script>", ["span"])).toBe(
+      "&lt;script&gt;alert('some alert')&lt;/script&gt;"
+    );
   });
 });

--- a/src/utils/renderHtml/sanitizeHtml.ts
+++ b/src/utils/renderHtml/sanitizeHtml.ts
@@ -5,10 +5,14 @@
  */
 const sanitizeHtml = (html: string, allowedTags: string[]) =>
   html.replace(/<[^<>]+>/g, (fakeTag) => {
+    // Check if the tag is a closing tag
     if (fakeTag.includes("</")) {
-      // @ts-expect-error
-      const tagName = fakeTag.match(/^<\/([^\s>]+)/)[1];
+      const tagName = fakeTag.match(/^<\/([^\s>]+)/)?.[1];
+      if (tagName === undefined) {
+        return fakeTag;
+      }
       if (allowedTags.includes(tagName)) {
+        // Allow the tag if it is allowed
         return fakeTag;
       }
       return fakeTag.replace(/[<>]/g, (match) => {
@@ -18,8 +22,11 @@ const sanitizeHtml = (html: string, allowedTags: string[]) =>
         return "&gt;";
       });
     }
-    // @ts-expect-error
-    const tagName = fakeTag.match(/^<([^\s>]+)/)[1];
+    // handle opening tags
+    const tagName = fakeTag.match(/^<([^\s>]+)/)?.[1];
+    if (tagName === undefined) {
+      return fakeTag;
+    }
     if (allowedTags.includes(tagName)) {
       return fakeTag;
     }

--- a/src/utils/renderHtml/sanitizeHtml.ts
+++ b/src/utils/renderHtml/sanitizeHtml.ts
@@ -1,0 +1,34 @@
+/**
+ * `sanitizeHtml` is a utility function that takes a string of HTML and returns a version that sanitizes the tags that are not allowed
+ * @param html - The html string to sanitize
+ * @returns The sanitized html string
+ */
+const sanitizeHtml = (html: string, allowedTags: string[]) =>
+  html.replace(/<[^<>]+>/g, (fakeTag) => {
+    if (fakeTag.includes("</")) {
+      // @ts-expect-error
+      const tagName = fakeTag.match(/^<\/([^\s>]+)/)[1];
+      if (allowedTags.includes(tagName)) {
+        return fakeTag;
+      }
+      return fakeTag.replace(/[<>]/g, (match) => {
+        if (match === "<") {
+          return "&lt;";
+        }
+        return "&gt;";
+      });
+    }
+    // @ts-expect-error
+    const tagName = fakeTag.match(/^<([^\s>]+)/)[1];
+    if (allowedTags.includes(tagName)) {
+      return fakeTag;
+    }
+    return fakeTag.replace(/[<>]/g, (match) => {
+      if (match === "<") {
+        return "&lt;";
+      }
+      return "&gt;";
+    });
+  });
+
+export { sanitizeHtml };


### PR DESCRIPTION
EVG-18447

### Description 
DomParser which is used by `html-react-parser` under the hood was incorrectly parsing the nodes in the html string. When it would encounter a value that resembles a tag it would automatically close the tags despite them not needing to be closed/ not being html tags. This would cause these strings to not render because we were omitting the children.

I replaced this logic with a `sanitizeHtml` function which uses a set of regex to verify if a tag is a real tag and should be sanitized. 
### Screenshots
Before:
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/4605522/205981563-ad7535f5-cae5-4d4b-8b03-452495ed9039.png">

After:
<img width="1413" alt="image" src="https://user-images.githubusercontent.com/4605522/205981516-7f7affef-5c87-4bff-9ff4-e797bcfa5dd1.png">

### Testing 
Wrote tests and tested the log in the ticket

