### PR TITLE
EVG-18442 Skip logkeeper metadata query if not a resmoke build

### DIFF
--- a/src/pages/LogView/LoadingPage/index.tsx
+++ b/src/pages/LogView/LoadingPage/index.tsx
@@ -42,7 +42,7 @@ const LoadingPage: React.FC<LoadingPageProps> = ({ logType }) => {
   const { data: logkeeperMetadata } = useFetch<LogkeeperMetadata>(
     getResmokeLogURL(buildID || "", { testID, metadata: true }),
     {
-      skip: !buildID,
+      skip: buildID === undefined,
     }
   );
   switch (logType) {


### PR DESCRIPTION
EVG-18442

### Description 
Skip logkeeper metadata query if not a  resmoke build
