### PR TITLE
EVG-18542: Add icon button for shortcut modal

### DIFF
--- a/cypress/integration/shortcuts.ts
+++ b/cypress/integration/shortcuts.ts
@@ -4,12 +4,17 @@ describe("Shortcuts", () => {
     cy.login();
   });
 
-  it("should be possible to open and close the keyboard shortcut modal", () => {
+  it("should be able to open and close the keyboard shortcut modal using keyboard shortcut", () => {
     cy.visit("/");
     cy.dataCy("shortcut-modal").should("not.exist");
     cy.get("body").type("{shift}", { release: false }).type("{?}");
     cy.dataCy("shortcut-modal").should("be.visible");
     cy.get("body").type("{shift}", { release: false }).type("{?}");
     cy.dataCy("shortcut-modal").should("not.exist");
+  });
+
+  it("should be able to open the keyboard shortcut modal by clicking navbar icon button", () => {
+    cy.get(`[aria-label="Click to open shortcut modal"]`).click();
+    cy.dataCy("shortcut-modal").should("be.visible");
   });
 });

--- a/cypress/integration/shortcuts.ts
+++ b/cypress/integration/shortcuts.ts
@@ -2,10 +2,10 @@
 describe("Shortcuts", () => {
   beforeEach(() => {
     cy.login();
+    cy.visit("/");
   });
 
   it("should be able to open and close the keyboard shortcut modal using keyboard shortcut", () => {
-    cy.visit("/");
     cy.dataCy("shortcut-modal").should("not.exist");
     cy.get("body").type("{shift}", { release: false }).type("{?}");
     cy.dataCy("shortcut-modal").should("be.visible");

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -95,7 +95,7 @@ const NavBar: React.FC = () => {
 
       <FlexContainer>
         <IconButton
-          aria-labelledby="Click to open shortcut modal"
+          aria-label="Click to open shortcut modal"
           onClick={() => setOpen(true)}
         >
           <Icon glyph="InfoWithCircle" />

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -1,10 +1,13 @@
+import { useState } from "react";
 import styled from "@emotion/styled";
+import IconButton from "@leafygreen-ui/icon-button";
 import { palette } from "@leafygreen-ui/palette";
 import { useLogWindowAnalytics } from "analytics";
 import DetailsOverlay from "components/DetailsOverlay";
 import Icon from "components/Icon";
 import PopoverButton from "components/PopoverButton";
 import SearchBar from "components/SearchBar";
+import ShortcutModal from "components/ShortcutModal";
 import { StyledLink } from "components/styles";
 import { CaseSensitivity, MatchType, SearchBarActions } from "constants/enums";
 import { QueryParams } from "constants/queryParams";
@@ -19,6 +22,7 @@ import UploadLink from "./UploadLink";
 const { gray, white } = palette;
 
 const NavBar: React.FC = () => {
+  const [open, setOpen] = useState(false);
   const [filters, setFilters] = useFilterParam();
   const [highlights, setHighlights] = useQueryParam<string[]>(
     QueryParams.Highlights,
@@ -89,13 +93,23 @@ const NavBar: React.FC = () => {
         )}
       </FlexContainer>
 
-      <StyledButton
-        buttonText="Details"
-        data-cy="details-button"
-        disabled={!hasLogs}
-      >
-        <DetailsOverlay data-cy="details-overlay" />
-      </StyledButton>
+      <FlexContainer>
+        <IconButton
+          aria-labelledby="Click to open shortcut modal"
+          onClick={() => setOpen(true)}
+        >
+          <Icon glyph="InfoWithCircle" />
+        </IconButton>
+        <StyledButton
+          buttonText="Details"
+          data-cy="details-button"
+          disabled={!hasLogs}
+        >
+          <DetailsOverlay data-cy="details-overlay" />
+        </StyledButton>
+      </FlexContainer>
+
+      <ShortcutModal open={open} setOpen={setOpen} />
     </Container>
   );
 };

--- a/src/components/ShortcutModal/ShortcutModal.test.tsx
+++ b/src/components/ShortcutModal/ShortcutModal.test.tsx
@@ -1,11 +1,17 @@
+import { useState } from "react";
 import { render, screen, userEvent, waitFor } from "test_utils";
 import ShortcutModal from ".";
+
+const ModalWrapper = () => {
+  const [open, setOpen] = useState(false);
+  return <ShortcutModal open={open} setOpen={setOpen} />;
+};
 
 describe("shortcutModal", () => {
   const user = userEvent.setup();
 
   it("should toggle open and closed when the user presses the question mark", async () => {
-    render(<ShortcutModal />);
+    render(<ModalWrapper />);
     expect(screen.queryByDataCy("shortcut-modal")).toBeNull();
 
     await user.keyboard("{Shift>}{?}{/Shift}");
@@ -20,7 +26,7 @@ describe("shortcutModal", () => {
   });
 
   it("should close when the user clicks outside of the modal", async () => {
-    render(<ShortcutModal />);
+    render(<ModalWrapper />);
     expect(screen.queryByDataCy("shortcut-modal")).toBeNull();
 
     await user.keyboard("{Shift>}{?}{/Shift}");

--- a/src/components/ShortcutModal/index.tsx
+++ b/src/components/ShortcutModal/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import styled from "@emotion/styled";
 import Modal from "@leafygreen-ui/modal";
 import { Body, H3, InlineKeyCode } from "@leafygreen-ui/typography";
@@ -32,8 +32,12 @@ const shortcuts = [
   },
 ];
 
-const ShortcutModal: React.FC = () => {
-  const [open, setOpen] = useState(false);
+interface ShortcutModalProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const ShortcutModal: React.FC<ShortcutModalProps> = ({ open, setOpen }) => {
   const modalRef = useRef<HTMLDivElement>(null);
 
   useKeyboardShortcut(

--- a/src/components/ShortcutModal/index.tsx
+++ b/src/components/ShortcutModal/index.tsx
@@ -7,6 +7,7 @@ import { size, zIndex } from "constants/tokens";
 import { useKeyboardShortcut, useOnClickOutside } from "hooks";
 
 const shortcuts = [
+  { keys: [["SHIFT", "?"]], description: "Open or close the shortcut modal" },
   {
     keys: [
       ["CTRL", "F"],

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import { Suspense, lazy } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { useAnalyticAttributes } from "analytics";
-import ShortcutModal from "components/ShortcutModal";
+
 import { PageLayout } from "components/styles";
 import { LogTypes } from "constants/enums";
 import routes from "constants/routes";
@@ -42,7 +42,6 @@ const Content: React.FC = () => {
         />
         <Route element={<NotFound />} path="*" />
       </Routes>
-      <ShortcutModal />
     </PageLayout>
   );
 };


### PR DESCRIPTION
EVG-18542

### Description 
This PR adds an icon button in the `NavBar` which when clicked will open the `ShortcutModal`.

#### Note
- In [EVG-18166](https://jira.mongodb.org/browse/EVG-18166), I'll do some more refactoring around the `NavBar` because it currently contains too much logic that is not related to the `NavBar` itself.

### Screenshots
<img width="1625" alt="Screen Shot 2022-12-13 at 12 09 29 PM" src="https://user-images.githubusercontent.com/47064971/207400148-447380ba-2c2a-4b8f-8f08-c51fc1598f9a.png">


### Testing 
- Added tests in `shortcuts.ts` (Cypress)
