### PR TITLE
EVG-18633 Avoid processing log files twice

### DIFF
--- a/src/context/LogContext/index.tsx
+++ b/src/context/LogContext/index.tsx
@@ -216,6 +216,19 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
       ? searchResults[state.searchState.searchIndex]
       : undefined;
 
+  const ingestLines = useCallback(
+    (lines: string[], logType: LogTypes) => {
+      dispatch({ type: "INGEST_LOGS", logs: lines, logType });
+    },
+    [dispatch]
+  );
+
+  const setLogMetadata = useCallback(
+    (logMetadata: LogMetadata) => {
+      dispatch({ type: "SET_LOG_METADATA", logMetadata });
+    },
+    [dispatch]
+  );
   const memoizedContext = useMemo(
     () => ({
       expandedLines: state.expandedLines,
@@ -267,9 +280,7 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
         dispatch({ type: "EXPAND_LINES", expandedLines }),
       getLine,
       getResmokeLineColor,
-      ingestLines: (lines: string[], logType: LogTypes) => {
-        dispatch({ type: "INGEST_LOGS", logs: lines, logType });
-      },
+      ingestLines,
       paginate: (direction: DIRECTION) => {
         const { searchIndex, searchRange } = state.searchState;
         if (searchIndex !== undefined && searchRange !== undefined) {
@@ -286,34 +297,34 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
       setFileName: (fileName: string) => {
         dispatch({ type: "SET_FILE_NAME", fileName });
       },
-      setLogMetadata: (logMetadata: LogMetadata) => {
-        dispatch({ type: "SET_LOG_METADATA", logMetadata });
-      },
+      setLogMetadata,
       setSearch: (searchTerm: string) => {
         dispatch({ type: "SET_SEARCH_TERM", searchTerm });
       },
     }),
     [
-      state.expandedLines,
-      state.logMetadata,
-      state.logs.length,
-      state.searchState,
+      expandableRows,
+      filterLogic,
       highlightedLine,
       lowerRange,
       matchingLines,
       prettyPrint,
       processedLogLines,
       searchResults,
+      state.expandedLines,
+      state.logMetadata,
+      state.logs.length,
+      state.searchState,
       upperRange,
+      wrap,
       dispatch,
       getLine,
       getResmokeLineColor,
+      ingestLines,
       scrollToLine,
-      wrap,
-      filterLogic,
-      setFilterLogic,
-      expandableRows,
       setExpandableRows,
+      setFilterLogic,
+      setLogMetadata,
     ]
   );
 

--- a/src/test_utils/hooks.ts
+++ b/src/test_utils/hooks.ts
@@ -1,0 +1,56 @@
+import { DependencyList, EffectCallback, useEffect, useRef } from "react";
+
+const usePrevious = <T>(value: T, initialValue: T) => {
+  const ref = useRef(initialValue);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
+/**
+ * `useEffectDebugger` is a custom hook that logs the changed dependencies of a useEffect hook
+ *
+ * @param effectHook - the effect hook
+ * @param dependencies - an array of dependencies
+ * @param dependencyNames - an array of strings that correspond to the dependencies
+ */
+const useEffectDebugger = (
+  effectHook: EffectCallback,
+  dependencies: DependencyList,
+  dependencyNames: string[] = []
+) => {
+  if (process.env.NODE_ENV !== "development") {
+    console.warn(
+      "[use-effect-debugger] This hook should only be used in development!"
+    );
+  }
+  const previousDeps = usePrevious(dependencies, []);
+
+  const changedDeps = dependencies.reduce(
+    (accum: Record<string, { before: any; after: any }>, dependency, index) => {
+      if (dependency !== previousDeps[index]) {
+        const keyName = dependencyNames[index] || index;
+        return {
+          ...accum,
+          [keyName]: {
+            before: previousDeps[index],
+            after: dependency,
+          },
+        };
+      }
+
+      return accum;
+    },
+    {} as Record<string, { before: any; after: any }>
+  );
+
+  if (Object.keys(changedDeps).length) {
+    console.log("[use-effect-debugger] ");
+    console.table(changedDeps);
+  }
+
+  useEffect(effectHook, dependencies);
+};
+
+export { useEffectDebugger };

--- a/src/test_utils/hooks.ts
+++ b/src/test_utils/hooks.ts
@@ -1,5 +1,11 @@
 import { DependencyList, EffectCallback, useEffect, useRef } from "react";
 
+/**
+ * `usePrevious` is a custom hook that returns the previous value of a given value
+ * @param value
+ * @param initialValue
+ * @returns
+ */
 const usePrevious = <T>(value: T, initialValue: T) => {
   const ref = useRef(initialValue);
   useEffect(() => {

--- a/src/test_utils/hooks.ts
+++ b/src/test_utils/hooks.ts
@@ -31,6 +31,11 @@ const useEffectDebugger = (
       "[use-effect-debugger] This hook should only be used in development!"
     );
   }
+  if (dependencies.length !== dependencyNames.length) {
+    console.warn(
+      "[use-effect-debugger] The number of dependencies and dependency names should be the same!"
+    );
+  }
   const previousDeps = usePrevious(dependencies, []);
 
   const changedDeps = dependencies.reduce(


### PR DESCRIPTION
EVG-18633

### Description 
Introduces a `useEffectDebugger` hook which performs the same functionality as a useEffect but will also log the dependencies that have changed.

While investigating the above hook I realized we were processing log files twice due to an unstable dependency that was being re-initialized whenever the context would update.

