### PR TITLE
EVG-18534: Select text content on Ctrl-F shortcut

### DIFF
--- a/src/components/Search/SearchBar/SearchBar.test.tsx
+++ b/src/components/Search/SearchBar/SearchBar.test.tsx
@@ -133,24 +133,34 @@ describe("searchbar", () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith("search", "test1");
   });
-  it("pressing Control+F puts focus on the input", async () => {
+  it("pressing Control+F puts focus on the input and selects the text content", async () => {
     const user = userEvent.setup();
     render(<SearchBar onSubmit={jest.fn()} />);
 
-    const input = screen.getByDataCy("searchbar-input");
+    const input = screen.getByDataCy("searchbar-input") as HTMLInputElement;
+    const inputText = "input text";
+    await user.type(input, inputText);
+    await user.click(document.body as HTMLElement);
     expect(input).not.toHaveFocus();
 
     await user.keyboard("{Control>}{f}");
     expect(input).toHaveFocus();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(inputText.length);
   });
-  it("pressing Command+F puts focus on the input", async () => {
+  it("pressing Command+F puts focus on the input and selects the text content", async () => {
     const user = userEvent.setup();
     render(<SearchBar onSubmit={jest.fn()} />);
 
-    const input = screen.getByDataCy("searchbar-input");
+    const input = screen.getByDataCy("searchbar-input") as HTMLInputElement;
+    const inputText = "input text";
+    await user.type(input, inputText);
+    await user.click(document.body as HTMLElement);
     expect(input).not.toHaveFocus();
 
     await user.keyboard("{Meta>}{f}");
     expect(input).toHaveFocus();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(inputText.length);
   });
 });

--- a/src/components/Search/SearchBar/index.tsx
+++ b/src/components/Search/SearchBar/index.tsx
@@ -43,10 +43,8 @@ const SearchBar: React.FC<SearchBarProps> = ({
   useKeyboardShortcut(
     { charKey: CharKey.F, modifierKeys: [ModifierKey.Control] },
     () => {
-      if (inputRef.current) {
-        inputRef.current.focus();
-        inputRef.current.select();
-      }
+      inputRef.current?.focus();
+      inputRef.current?.select();
     },
     { disabled, ignoreFocus: true }
   );

--- a/src/components/Search/SearchBar/index.tsx
+++ b/src/components/Search/SearchBar/index.tsx
@@ -43,7 +43,10 @@ const SearchBar: React.FC<SearchBarProps> = ({
   useKeyboardShortcut(
     { charKey: CharKey.F, modifierKeys: [ModifierKey.Control] },
     () => {
-      if (inputRef.current) inputRef.current.focus();
+      if (inputRef.current) {
+        inputRef.current.focus();
+        inputRef.current.select();
+      }
     },
     { disabled, ignoreFocus: true }
   );


### PR DESCRIPTION
EVG-18534

### Description 
This PR makes it so that using the Ctrl-F shortcut also selects any text that exists within the search bar.

### Screenshots
https://user-images.githubusercontent.com/47064971/210426919-4daa0cc6-c247-4bed-87ed-c23cfcf272c1.mov

### Testing 
- Modified `SearchBar.test.tsx`
