### PR TITLE
EVG-18656 Fix OOM when running long running cypress tests locally

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     specPattern: "cypress/integration/**/*.ts",
     experimentalStudio: true,
     testIsolation: false,
+    numTestsKeptInMemory: 0,
   },
   reporterOptions: {
     mochaFile: "bin/cypress/cypress-[hash].xml",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@typescript-eslint/parser": "5.42.0",
     "@vitejs/plugin-react": "3.0.0",
     "babel-loader": "8.2.5",
-    "cypress": "12.1.0",
+    "cypress": "12.3.0",
     "env-cmd": "10.1.0",
     "eslint": "8.26.0",
     "eslint-config-airbnb": "19.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6409,10 +6409,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==
 
-cypress@12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.1.0.tgz#1fdaa631bc30df466dc9505154616f4cf69dbd4b"
-  integrity sha512-7fz8N84uhN1+ePNDsfQvoWEl4P3/VGKKmAg+bJQFY4onhA37Ys+6oBkGbNdwGeC7n2QqibNVPhk8x3YuQLwzfw==
+cypress@12.3.0:
+  version "12.3.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.3.0.tgz#ae3fb0540aef4b5eab1ef2bcd0760caf2992b8bf"
+  integrity sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
EVG-18656

### Description 
There appears to be some sort of problem with the more recent versions of cypress and chrome. Long-running tests are OOMing and crashing when run locally. Taking a look at the memory usage of the cypress process the longer the test runs the more memory it uses until it crashes. Luckily there's a flag we can toggle to help out with this but we should keep an eye on the issue for future cypress releases.
https://github.com/cypress-io/cypress/issues/21135
https://github.com/cypress-io/cypress/issues/23391
https://github.com/cypress-io/cypress/issues/24905 

Also updates cypress for good measure https://docs.cypress.io/guides/references/changelog#12-3-0 
### Screenshots
Cypress Memory usage
Before:
https://user-images.githubusercontent.com/4605522/210657670-3a45a3a3-6bee-4641-ab74-23d97a1d449e.mov
After:
<img width="499" alt="image" src="https://user-images.githubusercontent.com/4605522/210657891-038c85b1-2abb-4b97-a926-bea981ef453c.png">

### Testing 
Run cypress tests locally in chrome should no longer OOM (resmoke_filtering in particular)
