### PR TITLE
EVG-18666 Fetch agent logs correctly

### DIFF
--- a/src/constants/logURLTemplates.ts
+++ b/src/constants/logURLTemplates.ts
@@ -52,7 +52,7 @@ const getResmokeLogURL = (
   return `${logkeeperURL}/build/${buildID}/all?${stringifyQuery(params)}`;
 };
 
-enum originToType {
+enum OriginToType {
   agent = "E",
   system = "S",
   task = "T",
@@ -64,18 +64,18 @@ enum originToType {
  * @param execution - the execution number of the task
  * @param origin - the origin of the log
  * @param options.text - returns the raw log associated with the task
- * @returns /task/${taskID}/${execution}?type=${originToType[origin]}&text=true
+ * @returns /task/${taskID}/${execution}?type=${OriginToType[origin]}&text=true
  */
 const getEvergreenTaskLogURL = (
   taskID: string,
   execution: string | number,
-  origin: keyof typeof originToType,
+  origin: keyof typeof OriginToType,
   options: { text?: boolean }
 ) => {
   const { text } = options;
   const params = {
     text,
-    type: originToType[origin] || undefined,
+    type: OriginToType[origin] || undefined,
   };
   return `${evergreenURL}/task_log_raw/${taskID}/${execution}?${stringifyQuery(
     params

--- a/src/constants/logURLTemplates.ts
+++ b/src/constants/logURLTemplates.ts
@@ -53,7 +53,7 @@ const getResmokeLogURL = (
 };
 
 enum originToType {
-  agent = "A",
+  agent = "E",
   system = "S",
   task = "T",
 }


### PR DESCRIPTION
EVG-18666

### Description 
Agent logs expect the letter E instead of A to be passed into the param.
https://github.com/evergreen-ci/evergreen/blob/24b4506727504198dd5cbbd47fb020c3e7e0a89a/rest/model/task.go#L321

Parsley beta link with above changes:
https://parsley-beta.corp.mongodb.com/evergreen/mongodb_mongo_master_enterprise_rhel_80_64_bit_dynamic_replica_sets_reconfig_jscore_stepdown_passthrough_4_linux_enterprise_8fd187d1f0c32a4d2fbf720e7f8c37b392c013b2_23_01_06_09_09_16/0/agent?bookmarks=0,258




