### PR TITLE
EVG-18397: Always enable Expand 5 button

### DIFF
--- a/src/components/LogRow/CollapsedRow/CollapsedRow.test.tsx
+++ b/src/components/LogRow/CollapsedRow/CollapsedRow.test.tsx
@@ -70,7 +70,7 @@ describe("collapsedRow", () => {
     expect(expandLines).toHaveBeenCalledWith([[0, 10]]);
   });
 
-  it("should disable the `Expand 5 Above and Below` button if there are less than 10 log lines in the collapsed row", async () => {
+  it("should not disable `Expand 5 Above and Below` button if there are less than 10 log lines in the collapsed row", async () => {
     renderWithRouterMatch(
       <CollapsedRow
         collapsedLines={[0, 1, 2]}
@@ -86,7 +86,7 @@ describe("collapsedRow", () => {
     const expandFiveButton = screen.getByRole("button", {
       name: "Expand Icon 5 Above and Below",
     });
-    expect(expandFiveButton).toBeDisabled();
+    expect(expandFiveButton).not.toBeDisabled();
   });
 });
 

--- a/src/components/LogRow/CollapsedRow/index.tsx
+++ b/src/components/LogRow/CollapsedRow/index.tsx
@@ -32,13 +32,17 @@ const CollapsedRow = forwardRef<any, CollapsedRowProps>((props, ref) => {
     numCollapsed !== 1 ? `${numCollapsed} lines skipped` : "1 line skipped";
 
   const expandFive = () => {
-    startTransition(() =>
-      expandLines([
-        [start, start + (SKIP_NUMBER - 1)],
-        [end - (SKIP_NUMBER - 1), end],
-      ])
-    );
-    sendEvent({ name: "Expanded Lines", lineCount: 5, option: "Five" });
+    if (2 * SKIP_NUMBER < numCollapsed) {
+      startTransition(() =>
+        expandLines([
+          [start, start + (SKIP_NUMBER - 1)],
+          [end - (SKIP_NUMBER - 1), end],
+        ])
+      );
+      sendEvent({ name: "Expanded Lines", lineCount: 5, option: "Five" });
+    } else {
+      expandAll();
+    }
   };
 
   const expandAll = () => {

--- a/src/components/LogRow/CollapsedRow/index.tsx
+++ b/src/components/LogRow/CollapsedRow/index.tsx
@@ -9,7 +9,7 @@ import { size } from "constants/tokens";
 import { OverlineType } from "types/leafygreen";
 import { BaseRowProps } from "../types";
 
-const { gray, black } = palette;
+const { gray } = palette;
 
 const SKIP_NUMBER = 5;
 
@@ -18,6 +18,9 @@ interface CollapsedRowProps extends BaseRowProps {
 }
 
 const CollapsedRow = forwardRef<any, CollapsedRowProps>((props, ref) => {
+  const { sendEvent } = useLogWindowAnalytics();
+  const [, startTransition] = useTransition();
+
   const { collapsedLines, data, listRowProps } = props;
   const { expandLines } = data;
 
@@ -27,25 +30,19 @@ const CollapsedRow = forwardRef<any, CollapsedRowProps>((props, ref) => {
 
   const lineText =
     numCollapsed !== 1 ? `${numCollapsed} lines skipped` : "1 line skipped";
-  const disableExpandFive = 2 * SKIP_NUMBER > numCollapsed;
-
-  const [, startTransition] = useTransition();
-  const { sendEvent } = useLogWindowAnalytics();
 
   const expandFive = () => {
-    startTransition(() => {
+    startTransition(() =>
       expandLines([
         [start, start + (SKIP_NUMBER - 1)],
         [end - (SKIP_NUMBER - 1), end],
-      ]);
-    });
+      ])
+    );
     sendEvent({ name: "Expanded Lines", lineCount: 5, option: "Five" });
   };
 
   const expandAll = () => {
-    startTransition(() => {
-      expandLines([[start, end]]);
-    });
+    startTransition(() => expandLines([[start, end]]));
     sendEvent({
       name: "Expanded Lines",
       lineCount: numCollapsed,
@@ -68,11 +65,7 @@ const CollapsedRow = forwardRef<any, CollapsedRowProps>((props, ref) => {
         All
       </StyledButton>
       <StyledButton
-        disabled={disableExpandFive}
-        leftGlyph={
-          // TODO: Remove conditional color when LG-2528 is completed.
-          <Icon fill={disableExpandFive ? gray.base : black} glyph="Expand" />
-        }
+        leftGlyph={<Icon glyph="Expand" />}
         onClick={expandFive}
         size="xsmall"
       >

--- a/src/components/LogRow/CollapsedRow/index.tsx
+++ b/src/components/LogRow/CollapsedRow/index.tsx
@@ -39,10 +39,10 @@ const CollapsedRow = forwardRef<any, CollapsedRowProps>((props, ref) => {
           [end - (SKIP_NUMBER - 1), end],
         ])
       );
-      sendEvent({ name: "Expanded Lines", lineCount: 5, option: "Five" });
     } else {
-      expandAll();
+      startTransition(() => expandLines([[start, end]]));
     }
+    sendEvent({ name: "Expanded Lines", lineCount: 5, option: "Five" });
   };
 
   const expandAll = () => {

--- a/src/components/LogRow/CollapsedRow/index.tsx
+++ b/src/components/LogRow/CollapsedRow/index.tsx
@@ -28,11 +28,12 @@ const CollapsedRow = forwardRef<any, CollapsedRowProps>((props, ref) => {
   const start = collapsedLines[0];
   const end = collapsedLines[collapsedLines.length - 1];
 
+  const canExpandFive = SKIP_NUMBER * 2 < numCollapsed;
   const lineText =
     numCollapsed !== 1 ? `${numCollapsed} lines skipped` : "1 line skipped";
 
   const expandFive = () => {
-    if (2 * SKIP_NUMBER < numCollapsed) {
+    if (canExpandFive) {
       startTransition(() =>
         expandLines([
           [start, start + (SKIP_NUMBER - 1)],
@@ -42,7 +43,11 @@ const CollapsedRow = forwardRef<any, CollapsedRowProps>((props, ref) => {
     } else {
       startTransition(() => expandLines([[start, end]]));
     }
-    sendEvent({ name: "Expanded Lines", lineCount: 5, option: "Five" });
+    sendEvent({
+      name: "Expanded Lines",
+      lineCount: canExpandFive ? SKIP_NUMBER * 2 : numCollapsed,
+      option: "Five",
+    });
   };
 
   const expandAll = () => {

--- a/src/utils/expandedLines/expandedLines.test.ts
+++ b/src/utils/expandedLines/expandedLines.test.ts
@@ -1,7 +1,7 @@
 import { isExpanded, mergeIntervals } from ".";
 
 describe("mergeIntervals", () => {
-  it("merges intervals if they can be merged", () => {
+  it("merges overlapping intervals when end + 1 === start", () => {
     expect(
       mergeIntervals([
         [89, 94],
@@ -9,6 +9,16 @@ describe("mergeIntervals", () => {
         [97, 102],
       ])
     ).toStrictEqual([[89, 102]]);
+  });
+
+  it("merges overlapping intervals when end + 1 > start", () => {
+    expect(
+      mergeIntervals([
+        [0, 5],
+        [3, 15],
+        [7, 28],
+      ])
+    ).toStrictEqual([[0, 28]]);
   });
 
   it("does not merge intervals if they cannot be merged", () => {

--- a/src/utils/expandedLines/index.ts
+++ b/src/utils/expandedLines/index.ts
@@ -18,9 +18,10 @@ export const mergeIntervals = (intervals: ExpandedLines) => {
   let current = intervals[0];
 
   for (let i = 1; i < intervals.length; i++) {
-    // If current interval's END + 1 equals next interval's START, the intervals can be merged.
-    if (current[1] + 1 === intervals[i][0]) {
-      current = [current[0], intervals[i][1]];
+    // If current interval + 1 overlaps next interval, the intervals can be merged.
+    if (current[1] + 1 >= intervals[i][0]) {
+      const end = Math.max(current[1], intervals[i][1]);
+      current = [current[0], end];
     } else {
       mergedIntervals.push(current);
       current = intervals[i];


### PR DESCRIPTION
EVG-18397

### Description 
This PR makes it so the `Expand 5 Above and Below` button is always enabled. It also modifies `mergeIntervals` function to be slightly more robust.

### Screenshots
<img width="559" alt="Screen Shot 2023-01-09 at 12 11 36 PM" src="https://user-images.githubusercontent.com/47064971/211366746-43b8c7f8-6062-4dc0-ac43-eddf650e951d.png">


### Testing 
- Added test in `utils/expandedLines/expandedLines.test.ts`
