### PR TITLE
EVG-18493 Fix bug causing strange log rendering for ansi logs

### DIFF
--- a/src/components/LogRow/AnsiiRow/index.tsx
+++ b/src/components/LogRow/AnsiiRow/index.tsx
@@ -5,13 +5,12 @@ import BaseRow from "components/LogRow/BaseRow";
 import { BaseRowProps } from "../types";
 import { isLineInRange } from "../utils";
 
-const ansiUp = new AnsiUp();
-
 interface AnsiiRowProps extends BaseRowProps {
   lineNumber: number;
 }
 
 const AnsiiRow = forwardRef<any, AnsiiRowProps>((rowProps, ref) => {
+  const ansiUp = new AnsiUp();
   const { data, listRowProps, lineNumber } = rowProps;
   const {
     getLine,


### PR DESCRIPTION
EVG-18493

### Description 
I think declaring AnsiUp as a singleton was causing it to get confused and would cause it to highlight the wrong lines sometimes. 

### Screenshots

https://user-images.githubusercontent.com/4605522/211610856-cbf0091e-2481-422c-96f5-10814f395aae.mov


### Testing 
Scrolling no longer causes log line color corruption.  I can't think of a clear way to introduce any tests for this since it it was flaky. 
