### PR TITLE
EVG-18681: Enable test isolation in Cypress

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
     supportFile: "cypress/support/index.ts",
     specPattern: "cypress/integration/**/*.ts",
     experimentalStudio: true,
-    testIsolation: false,
     numTestsKeptInMemory: 0,
   },
   reporterOptions: {

--- a/cypress/integration/ansiiLogs/ansii_filtering.ts
+++ b/cypress/integration/ansiiLogs/ansii_filtering.ts
@@ -4,7 +4,7 @@ describe("Filtering", () => {
 
   describe("Applying filters", () => {
     describe("Basic filtering", () => {
-      before(() => {
+      beforeEach(() => {
         cy.login();
         cy.setCookie("has-opened-drawer", "true");
         cy.visit(logLink);
@@ -35,57 +35,71 @@ describe("Filtering", () => {
       const filter2 = "storybook";
 
       describe("filtering mode is AND", () => {
-        before(() => {
+        beforeEach(() => {
           cy.login();
-          cy.visit(`${logLink}/?filterLogic=and`);
-          cy.dataCy("clear-bookmarks").click();
         });
 
         it("should be able to apply two default filters (case insensitive, exact match)", () => {
+          cy.visit(`${logLink}?filterLogic=and`);
           cy.addFilter(filter1);
           cy.addFilter(filter2);
           cy.location("search").should(
-            "equal",
-            `?filterLogic=and&filters=100${filter1},100${filter2}`
+            "contain",
+            `filters=100${filter1},100${filter2}`
           );
-
-          cy.get("[data-cy^='log-row-']").each(($el) => {
-            cy.wrap($el).contains(filter1, { matchCase: false });
-            cy.wrap($el).contains(filter2, { matchCase: false });
-          });
+          cy.get("[data-cy^='log-row-']")
+            .not("[data-cy='log-row-0']")
+            .not("[data-cy='log-row-297']")
+            .each(($el) => {
+              cy.wrap($el).contains(filter1, { matchCase: false });
+              cy.wrap($el).contains(filter2, { matchCase: false });
+            });
         });
 
         it("should be able to toggle case sensitivity", () => {
+          cy.visit(
+            `${logLink}?filterLogic=and&filters=100${filter1},100${filter2}`
+          );
           cy.dataCy(`filter-${filter1}`).within(() => {
             cy.contains("Sensitive").click();
           });
           cy.location("search").should(
-            "equal",
-            `?filterLogic=and&filters=110${filter1},100${filter2}`
+            "contain",
+            `filters=110${filter1},100${filter2}`
           );
-
-          cy.get("[data-cy^='log-row-']").each(($el) => {
-            cy.wrap($el).contains(filter1, { matchCase: true });
-            cy.wrap($el).contains(filter2, { matchCase: false });
-          });
+          cy.get("[data-cy^='log-row-']")
+            .not("[data-cy='log-row-0']")
+            .not("[data-cy='log-row-297']")
+            .each(($el) => {
+              cy.wrap($el).contains(filter1, { matchCase: true });
+              cy.wrap($el).contains(filter2, { matchCase: false });
+            });
         });
 
         it("should be able to toggle inverse matching", () => {
+          cy.visit(
+            `${logLink}?filterLogic=and&filters=110${filter1},100${filter2}`
+          );
           cy.dataCy(`filter-${filter2}`).within(() => {
             cy.contains("Inverse").click();
           });
           cy.location("search").should(
-            "equal",
-            `?filterLogic=and&filters=110${filter1},101${filter2}`
+            "contain",
+            `filters=110${filter1},101${filter2}`
           );
-
-          cy.get("[data-cy^='log-row-']").each(($el) => {
-            cy.wrap($el).contains(filter1, { matchCase: true });
-            cy.wrap($el).should("not.contain.text", filter2);
-          });
+          cy.get("[data-cy^='log-row-']")
+            .not("[data-cy='log-row-0']")
+            .not("[data-cy='log-row-297']")
+            .each(($el) => {
+              cy.wrap($el).contains(filter1, { matchCase: true });
+              cy.wrap($el).should("not.contain.text", filter2);
+            });
         });
 
         it("should be able to toggle visibility", () => {
+          cy.visit(
+            `${logLink}?filterLogic=and&filters=110${filter1},101${filter2}`
+          );
           cy.dataCy(`filter-${filter1}`).within(() => {
             cy.get(`[aria-label="Hide filter"]`).click();
           });
@@ -93,77 +107,90 @@ describe("Filtering", () => {
             cy.get(`[aria-label="Hide filter"]`).click();
           });
           cy.location("search").should(
-            "equal",
-            `?filterLogic=and&filters=010${filter1},001${filter2}`
+            "contain",
+            `filters=010${filter1},001${filter2}`
           );
-
           cy.get("[data-cy^='collapsed-row-']").should("not.exist");
         });
       });
 
       describe("filtering mode is OR", () => {
-        before(() => {
+        beforeEach(() => {
           cy.login();
-          cy.visit(`${logLink}/?filterLogic=or`);
-          cy.dataCy("clear-bookmarks").click();
         });
 
         it("should be able to apply two default filters (case insensitive, exact match)", () => {
+          cy.visit(`${logLink}?filterLogic=or`);
           cy.addFilter(filter1);
           cy.addFilter(filter2);
           cy.location("search").should(
-            "equal",
-            `?filterLogic=or&filters=100${filter1},100${filter2}`
+            "contain",
+            `filters=100${filter1},100${filter2}`
           );
-
-          cy.get("[data-cy^='log-row-']").each(($el) => {
-            cy.wrap($el)
-              .invoke("text")
-              .should("match", /Warning|storybook/i);
-          });
+          cy.get("[data-cy^='log-row-']")
+            .not("[data-cy='log-row-0']")
+            .not("[data-cy='log-row-297']")
+            .each(($el) => {
+              cy.wrap($el)
+                .invoke("text")
+                .should("match", /Warning|storybook/i);
+            });
         });
 
         it("should be able to toggle case sensitivity", () => {
+          cy.visit(
+            `${logLink}?filterLogic=or&filters=100${filter1},100${filter2}`
+          );
           cy.dataCy(`filter-${filter1}`).within(() => {
             cy.contains("Sensitive").click();
           });
           cy.location("search").should(
-            "equal",
-            `?filterLogic=or&filters=110${filter1},100${filter2}`
+            "contain",
+            `filters=110${filter1},100${filter2}`
           );
-
-          cy.get("[data-cy^='log-row-']").each(($el) => {
-            cy.wrap($el)
-              .invoke("text")
-              .should(
-                "satisfy",
-                (text: string) =>
-                  text.match(/Warning/) || text.match(/storybook/i)
-              );
-          });
+          cy.get("[data-cy^='log-row-']")
+            .not("[data-cy='log-row-0']")
+            .not("[data-cy='log-row-297']")
+            .each(($el) => {
+              cy.wrap($el)
+                .invoke("text")
+                .should(
+                  "satisfy",
+                  (text: string) =>
+                    text.match(/Warning/) || text.match(/storybook/i)
+                );
+            });
         });
 
         it("should be able to toggle inverse matching", () => {
+          cy.visit(
+            `${logLink}?filterLogic=or&filters=110${filter1},100${filter2}`
+          );
           cy.dataCy(`filter-${filter2}`).within(() => {
             cy.contains("Inverse").click();
           });
           cy.location("search").should(
-            "equal",
-            `?filterLogic=or&filters=110${filter1},101${filter2}`
+            "contain",
+            `filters=110${filter1},101${filter2}`
           );
-
-          cy.get("[data-cy^='log-row-']").each(($el) => {
-            cy.wrap($el)
-              .invoke("text")
-              .should(
-                "satisfy",
-                (text: string) =>
-                  text.match(/Warning/) || !text.match(/storybook/i)
-              );
-          });
+          cy.get("[data-cy^='log-row-']")
+            .not("[data-cy='log-row-0']")
+            .not("[data-cy='log-row-297']")
+            .each(($el) => {
+              cy.wrap($el)
+                .invoke("text")
+                .should(
+                  "satisfy",
+                  (text: string) =>
+                    text.match(/Warning/) || !text.match(/storybook/i)
+                );
+            });
         });
 
         it("should be able to toggle visibility", () => {
+          cy.visit(
+            `${logLink}?filterLogic=or&filters=110${filter1},101${filter2}`
+          );
           cy.dataCy(`filter-${filter1}`).within(() => {
             cy.get(`[aria-label="Hide filter"]`).click();
           });
@@ -171,10 +198,9 @@ describe("Filtering", () => {
             cy.get(`[aria-label="Hide filter"]`).click();
           });
           cy.location("search").should(
-            "equal",
-            `?filterLogic=or&filters=010${filter1},001${filter2}`
+            "contain",
+            `filters=010${filter1},001${filter2}`
           );
-
           cy.get("[data-cy^='collapsed-row-']").should("not.exist");
         });
       });
@@ -182,37 +208,41 @@ describe("Filtering", () => {
   });
 
   describe("Deleting and editing filters", () => {
-    before(() => {
+    beforeEach(() => {
       cy.login();
       cy.visit(logLink);
-      cy.dataCy("clear-bookmarks").click();
-      cy.location("search").should("equal", "");
     });
 
     it("should be able to edit a filter", () => {
       cy.addFilter("notarealfilter");
-      cy.location("search").should("equal", "?filters=100notarealfilter");
+      cy.location("search").should("contain", "filters=100notarealfilter");
 
-      cy.get("[data-cy^='log-row-']").should("not.exist");
+      cy.get("[data-cy^='log-row-']")
+        .not("[data-cy='log-row-0']")
+        .not("[data-cy='log-row-297']")
+        .should("not.exist");
 
       cy.dataCy("filter-notarealfilter").within(() => {
         cy.get(`[aria-label="Edit filter"]`).click();
       });
       cy.dataCy("edit-filter-name").clear().type("running");
       cy.contains("button", "Apply").click();
-      cy.location("search").should("equal", "?filters=100running");
+      cy.location("search").should("contain", "filters=100running");
 
-      cy.get("[data-cy^='log-row-']").each(($el) => {
-        cy.wrap($el).contains("running", { matchCase: false });
-      });
+      cy.get("[data-cy^='log-row-']")
+        .not("[data-cy='log-row-0']")
+        .not("[data-cy='log-row-297']")
+        .each(($el) => {
+          cy.wrap($el).contains("running", { matchCase: false });
+        });
     });
 
     it("should be able to delete a filter", () => {
+      cy.addFilter("running");
       cy.dataCy("filter-running").within(() => {
         cy.get(`[aria-label="Delete filter"]`).click();
       });
-      cy.location("search").should("equal", "");
-
+      cy.location("search").should("not.contain", "filters");
       cy.get("[data-cy^='collapsed-row-']").should("not.exist");
     });
   });

--- a/cypress/integration/ansiiLogs/ansii_filtering.ts
+++ b/cypress/integration/ansiiLogs/ansii_filtering.ts
@@ -48,8 +48,7 @@ describe("Filtering", () => {
             `filters=100${filter1},100${filter2}`
           );
           cy.get("[data-cy^='log-row-']")
-            .not("[data-cy='log-row-0']")
-            .not("[data-cy='log-row-297']")
+            .not("[data-bookmarked=true]")
             .each(($el) => {
               cy.wrap($el).contains(filter1, { matchCase: false });
               cy.wrap($el).contains(filter2, { matchCase: false });
@@ -68,8 +67,7 @@ describe("Filtering", () => {
             `filters=110${filter1},100${filter2}`
           );
           cy.get("[data-cy^='log-row-']")
-            .not("[data-cy='log-row-0']")
-            .not("[data-cy='log-row-297']")
+            .not("[data-bookmarked=true]")
             .each(($el) => {
               cy.wrap($el).contains(filter1, { matchCase: true });
               cy.wrap($el).contains(filter2, { matchCase: false });
@@ -88,8 +86,7 @@ describe("Filtering", () => {
             `filters=110${filter1},101${filter2}`
           );
           cy.get("[data-cy^='log-row-']")
-            .not("[data-cy='log-row-0']")
-            .not("[data-cy='log-row-297']")
+            .not("[data-bookmarked=true]")
             .each(($el) => {
               cy.wrap($el).contains(filter1, { matchCase: true });
               cy.wrap($el).should("not.contain.text", filter2);
@@ -128,8 +125,7 @@ describe("Filtering", () => {
             `filters=100${filter1},100${filter2}`
           );
           cy.get("[data-cy^='log-row-']")
-            .not("[data-cy='log-row-0']")
-            .not("[data-cy='log-row-297']")
+            .not("[data-bookmarked=true]")
             .each(($el) => {
               cy.wrap($el)
                 .invoke("text")
@@ -149,8 +145,7 @@ describe("Filtering", () => {
             `filters=110${filter1},100${filter2}`
           );
           cy.get("[data-cy^='log-row-']")
-            .not("[data-cy='log-row-0']")
-            .not("[data-cy='log-row-297']")
+            .not("[data-bookmarked=true]")
             .each(($el) => {
               cy.wrap($el)
                 .invoke("text")
@@ -174,8 +169,7 @@ describe("Filtering", () => {
             `filters=110${filter1},101${filter2}`
           );
           cy.get("[data-cy^='log-row-']")
-            .not("[data-cy='log-row-0']")
-            .not("[data-cy='log-row-297']")
+            .not("[data-bookmarked=true]")
             .each(($el) => {
               cy.wrap($el)
                 .invoke("text")
@@ -218,8 +212,7 @@ describe("Filtering", () => {
       cy.location("search").should("contain", "filters=100notarealfilter");
 
       cy.get("[data-cy^='log-row-']")
-        .not("[data-cy='log-row-0']")
-        .not("[data-cy='log-row-297']")
+        .not("[data-bookmarked=true]")
         .should("not.exist");
 
       cy.dataCy("filter-notarealfilter").within(() => {
@@ -230,8 +223,7 @@ describe("Filtering", () => {
       cy.location("search").should("contain", "filters=100running");
 
       cy.get("[data-cy^='log-row-']")
-        .not("[data-cy='log-row-0']")
-        .not("[data-cy='log-row-297']")
+        .not("[data-bookmarked=true]")
         .each(($el) => {
           cy.wrap($el).contains("running", { matchCase: false });
         });

--- a/cypress/integration/ansiiLogs/ansii_filtering.ts
+++ b/cypress/integration/ansiiLogs/ansii_filtering.ts
@@ -12,16 +12,13 @@ describe("Filtering", () => {
       });
 
       it("should not collapse bookmarks and selected line", () => {
-        // Bookmark and select a line, with the expectation that they won't be collapsed by the filter.
         cy.dataCy("log-link-5").click();
         cy.dataCy("log-row-6").dblclick();
         cy.location("search").should(
           "equal",
           "?bookmarks=0,6,297&selectedLine=5"
         );
-        // Apply a filter that doesn't satisfy any log line.
-        cy.addFilter("notarealfilter");
-        // Matched elements should be one of the bookmarked or selected values.
+        cy.addFilter("doesNotMatchAnything");
         cy.get("[data-cy^='log-row-']").each(($el) => {
           cy.wrap($el)
             .should("have.attr", "data-cy")
@@ -202,26 +199,21 @@ describe("Filtering", () => {
   });
 
   describe("Deleting and editing filters", () => {
+    const filter = "doesNotMatchAnything";
+
     beforeEach(() => {
       cy.login();
-      cy.visit(logLink);
+      cy.visit(`${logLink}?filters=100${filter}`);
+      cy.get("[data-cy^='collapsed-row-']").should("exist");
     });
 
     it("should be able to edit a filter", () => {
-      cy.addFilter("notarealfilter");
-      cy.location("search").should("contain", "filters=100notarealfilter");
-
-      cy.get("[data-cy^='log-row-']")
-        .not("[data-bookmarked=true]")
-        .should("not.exist");
-
-      cy.dataCy("filter-notarealfilter").within(() => {
+      cy.dataCy(`filter-${filter}`).within(() => {
         cy.get(`[aria-label="Edit filter"]`).click();
       });
       cy.dataCy("edit-filter-name").clear().type("running");
       cy.contains("button", "Apply").click();
       cy.location("search").should("contain", "filters=100running");
-
       cy.get("[data-cy^='log-row-']")
         .not("[data-bookmarked=true]")
         .each(($el) => {
@@ -230,8 +222,7 @@ describe("Filtering", () => {
     });
 
     it("should be able to delete a filter", () => {
-      cy.addFilter("running");
-      cy.dataCy("filter-running").within(() => {
+      cy.dataCy(`filter-${filter}`).within(() => {
         cy.get(`[aria-label="Delete filter"]`).click();
       });
       cy.location("search").should("not.contain", "filters");

--- a/cypress/integration/ansiiLogs/ansii_highlighting.ts
+++ b/cypress/integration/ansiiLogs/ansii_highlighting.ts
@@ -5,31 +5,23 @@ describe("Highlighting", () => {
     cy.login();
     cy.setCookie("has-opened-drawer", "true");
     cy.visit(logLink);
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("highlight-option").click();
   });
   it("applying a highlight should highlight the matching words", () => {
-    cy.dataCy("searchbar-input").type("@bugsnag/plugin-react@{enter}");
+    cy.addHighlight("@bugsnag/plugin-react@");
     cy.dataCy("highlight").should("exist");
     cy.dataCy("highlight").should("have.length", 1);
     cy.dataCy("highlight").should("contain.text", "@bugsnag/plugin-react@");
   });
   it("applying a search to a highlighted line should not overwrite an already highlighted term if the search matches the highlight ", () => {
-    cy.dataCy("searchbar-input").type("@bugsnag/plugin-react{enter}");
-
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("search-option").click();
-    cy.dataCy("searchbar-input").type("@bugsnag/plugin-react@{enter}");
+    cy.addHighlight("@bugsnag/plugin-react@");
+    cy.addSearch("@bugsnag/plugin-react@");
     cy.dataCy("highlight").should("exist");
     cy.dataCy("highlight").should("have.length", 1);
     cy.dataCy("highlight").should("contain.text", "@bugsnag/plugin-react");
   });
   it("should highlight other terms in the log if the search term does not match the highlight", () => {
-    cy.dataCy("searchbar-input").type("@bugsnag/plugin-react@{enter}");
-
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("search-option").click();
-    cy.dataCy("searchbar-input").type("info{enter}");
+    cy.addHighlight("@bugsnag/plugin-react@");
+    cy.addSearch("info");
     cy.dataCy("highlight").should("exist");
     cy.dataCy("highlight").should("have.length", 5);
     cy.dataCy("highlight").each(($el) => {
@@ -38,8 +30,8 @@ describe("Highlighting", () => {
         .should("match", /@bugsnag\/plugin-react@|info/);
     });
   });
-  it("removing a highlight from the sidenav should remove the highlight", () => {
-    cy.dataCy("searchbar-input").type("@bugsnag/plugin-react{enter}");
+  it("removing a highlight from the side panel should remove the highlight", () => {
+    cy.addHighlight("@bugsnag/plugin-react@");
     cy.dataCy("highlight").should("exist");
     cy.toggleDrawer();
     cy.dataCy("delete-highlight-button").should("be.visible");

--- a/cypress/integration/ansiiLogs/ansii_highlighting.ts
+++ b/cypress/integration/ansiiLogs/ansii_highlighting.ts
@@ -1,34 +1,35 @@
 describe("Highlighting", () => {
   const logLink =
     "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task";
-  before(() => {
+  beforeEach(() => {
     cy.login();
+    cy.setCookie("has-opened-drawer", "true");
     cy.visit(logLink);
-    cy.toggleDrawer();
     cy.dataCy("searchbar-select").click();
     cy.dataCy("highlight-option").click();
   });
   it("applying a highlight should highlight the matching words", () => {
-    cy.dataCy("searchbar-input").type("@bugsnag/plugin-react@");
-    cy.dataCy("searchbar-input").type("{enter}");
+    cy.dataCy("searchbar-input").type("@bugsnag/plugin-react@{enter}");
     cy.dataCy("highlight").should("exist");
     cy.dataCy("highlight").should("have.length", 1);
     cy.dataCy("highlight").should("contain.text", "@bugsnag/plugin-react@");
   });
   it("applying a search to a highlighted line should not overwrite an already highlighted term if the search matches the highlight ", () => {
-    cy.dataCy("searchbar-input").clear();
+    cy.dataCy("searchbar-input").type("@bugsnag/plugin-react{enter}");
+
     cy.dataCy("searchbar-select").click();
     cy.dataCy("search-option").click();
-    cy.dataCy("searchbar-input").type("@bugsnag/plugin-react");
-    cy.dataCy("searchbar-input").type("{enter}");
+    cy.dataCy("searchbar-input").type("@bugsnag/plugin-react@{enter}");
     cy.dataCy("highlight").should("exist");
     cy.dataCy("highlight").should("have.length", 1);
     cy.dataCy("highlight").should("contain.text", "@bugsnag/plugin-react");
   });
   it("should highlight other terms in the log if the search term does not match the highlight", () => {
-    cy.dataCy("searchbar-input").clear();
-    cy.dataCy("searchbar-input").type("info");
-    cy.dataCy("searchbar-input").type("{enter}");
+    cy.dataCy("searchbar-input").type("@bugsnag/plugin-react@{enter}");
+
+    cy.dataCy("searchbar-select").click();
+    cy.dataCy("search-option").click();
+    cy.dataCy("searchbar-input").type("info{enter}");
     cy.dataCy("highlight").should("exist");
     cy.dataCy("highlight").should("have.length", 5);
     cy.dataCy("highlight").each(($el) => {
@@ -37,13 +38,9 @@ describe("Highlighting", () => {
         .should("match", /@bugsnag\/plugin-react@|info/);
     });
   });
-  it("clearing a search should not clear a highlight", () => {
-    cy.dataCy("searchbar-input").clear();
-    cy.dataCy("highlight").should("exist");
-    cy.dataCy("highlight").should("have.length", 1);
-    cy.dataCy("highlight").should("contain.text", "@bugsnag/plugin-react@");
-  });
   it("removing a highlight from the sidenav should remove the highlight", () => {
+    cy.dataCy("searchbar-input").type("@bugsnag/plugin-react{enter}");
+    cy.dataCy("highlight").should("exist");
     cy.toggleDrawer();
     cy.dataCy("delete-highlight-button").should("be.visible");
     cy.dataCy("delete-highlight-button").click();

--- a/cypress/integration/ansiiLogs/ansii_logView.ts
+++ b/cypress/integration/ansiiLogs/ansii_logView.ts
@@ -9,9 +9,6 @@ describe("Basic evergreen log view", () => {
     cy.visit(logLink);
   });
 
-  it("should be able to see log lines", () => {
-    cy.dataCy("log-row-0").should("be.visible");
-  });
   it("should render ansii lines", () => {
     cy.dataCy("ansii-row").should("be.visible");
   });
@@ -35,15 +32,12 @@ describe("Basic evergreen log view", () => {
     cy.dataCy("log-row-22").isContainedInViewport();
   });
   it("should still allow horizontal scrolling when there are few logs on screen", () => {
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("filter-option").click();
-    cy.dataCy("searchbar-input").type("Putting spruce/{enter}");
+    cy.addFilter("Putting spruce/");
     cy.get(".ReactVirtualized__Grid").should(
       "have.css",
       "overflow-x",
       "scroll"
     );
-    // scroll to the right
     cy.get(".ReactVirtualized__Grid").scrollTo("right");
   });
 });
@@ -69,16 +63,17 @@ describe("Bookmarking and selecting lines", () => {
     cy.dataCy("bookmark-list").should("contain", "0");
     cy.dataCy("bookmark-list").should("contain", "4");
     cy.dataCy("bookmark-list").should("contain", "297");
-
     cy.dataCy("log-row-4").dblclick();
+    cy.location("search").should("equal", "?bookmarks=0,297");
     cy.dataCy("bookmark-list").should("not.contain", "4");
   });
 
-  it("should be able to select and unselect lines", () => {
+  it("should be able to set and unset the share line", () => {
     cy.dataCy("log-link-5").click();
     cy.location("search").should("equal", "?bookmarks=0,297&selectedLine=5");
+    cy.dataCy("bookmark-list").should("contain", "0");
     cy.dataCy("bookmark-list").should("contain", "5");
-
+    cy.dataCy("bookmark-list").should("contain", "297");
     cy.dataCy("log-link-5").click();
     cy.location("search").should("equal", "?bookmarks=0,297");
     cy.dataCy("bookmark-list").should("not.contain", "5");
@@ -125,19 +120,19 @@ describe("Jump to line", () => {
 
   it("should be able to use the bookmarks bar to jump to a line when there are no collapsed rows", () => {
     cy.visit(`${logLink}?bookmarks=0,297`);
-
     cy.dataCy("log-row-4").dblclick({ force: true });
+
     cy.dataCy("bookmark-297").click();
     cy.dataCy("log-row-297").should("be.visible");
-    cy.dataCy("log-row-56").should("not.exist");
+    cy.dataCy("log-row-4").should("not.exist");
     cy.dataCy("bookmark-4").click();
     cy.dataCy("log-row-4").should("be.visible");
   });
 
   it("should be able to use the bookmarks bar to jump to a line when there are collapsed rows", () => {
     cy.visit(`${logLink}?bookmarks=0,297&filters=100pass`);
-
     cy.dataCy("log-row-56").dblclick({ force: true });
+
     cy.dataCy("bookmark-297").click();
     cy.dataCy("log-row-297").should("be.visible");
     cy.dataCy("log-row-56").should("not.exist");
@@ -190,10 +185,7 @@ describe("expanding collapsed rows", () => {
     cy.dataCy("collapsed-row-1-4").within(() => {
       cy.contains("All").click();
     });
-    cy.dataCy("log-row-1").should("be.visible");
-    cy.dataCy("log-row-2").should("be.visible");
-    cy.dataCy("log-row-3").should("be.visible");
-    cy.dataCy("log-row-4").should("be.visible");
+    cy.dataCy("collapsed-row-1-4").should("not.exist");
 
     cy.toggleDrawer();
     cy.dataCy("expanded-row-1-to-4").within(() => {

--- a/cypress/integration/ansiiLogs/ansii_logView.ts
+++ b/cypress/integration/ansiiLogs/ansii_logView.ts
@@ -1,13 +1,14 @@
 describe("Basic evergreen log view", () => {
   const logLink =
     "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task";
-  before(() => {
+  const longLogLine = `[2022/03/02 17:02:18.500] warning Pattern ["@apollo/client@latest"] is trying to unpack in the same destination "/home/ubuntu/.cache/yarn/v6/npm-@apollo-client-3.3.7-f15bf961dc0c2bee37a47bf86b8881fdc6183810-integrity/node_modules/@apollo/client" as pattern ["@apollo/client@3.3.7"]. This could result in non-deterministic behavior, skipping.`;
+
+  beforeEach(() => {
     cy.login();
-    cy.visit(logLink);
     cy.setCookie("has-opened-drawer", "true");
+    cy.visit(logLink);
   });
 
-  const longLogLine = `[2022/03/02 17:02:18.500] warning Pattern ["@apollo/client@latest"] is trying to unpack in the same destination "/home/ubuntu/.cache/yarn/v6/npm-@apollo-client-3.3.7-f15bf961dc0c2bee37a47bf86b8881fdc6183810-integrity/node_modules/@apollo/client" as pattern ["@apollo/client@3.3.7"]. This could result in non-deterministic behavior, skipping.`;
   it("should be able to see log lines", () => {
     cy.dataCy("log-row-0").should("be.visible");
   });
@@ -28,11 +29,10 @@ describe("Basic evergreen log view", () => {
     });
   });
   it("long lines with wrapping turned on should fit on screen", () => {
-    cy.clickToggle("wrap-toggle", true); // Turn wrap on.
+    cy.clickToggle("wrap-toggle", true);
     cy.dataCy("log-row-22").should("be.visible");
     cy.dataCy("log-row-22").should("contain.text", longLogLine);
     cy.dataCy("log-row-22").isContainedInViewport();
-    cy.clickToggle("wrap-toggle", false); // Turn wrap off.
   });
   it("should still allow horizontal scrolling when there are few logs on screen", () => {
     cy.dataCy("searchbar-select").click();
@@ -51,10 +51,10 @@ describe("Basic evergreen log view", () => {
 describe("Bookmarking and selecting lines", () => {
   const logLink =
     "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task";
-  before(() => {
+  beforeEach(() => {
     cy.login();
-    cy.visit(logLink);
     cy.setCookie("has-opened-drawer", "true");
+    cy.visit(logLink);
   });
 
   it("should default to bookmarking 0 and the last log line on load", () => {
@@ -118,62 +118,50 @@ describe("Bookmarking and selecting lines", () => {
 describe("Jump to line", () => {
   const logLink =
     "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task";
-  before(() => {
+  beforeEach(() => {
     cy.login();
-    cy.visit(logLink);
-  });
-
-  it("should default to bookmarking 0 and the last log line on load", () => {
-    cy.location("search").should("equal", "?bookmarks=0,297");
-    cy.dataCy("bookmark-list").should("contain", "0");
-    cy.dataCy("bookmark-list").should("contain", "297");
+    cy.setCookie("has-opened-drawer", "true");
   });
 
   it("should be able to use the bookmarks bar to jump to a line when there are no collapsed rows", () => {
-    cy.dataCy("log-row-4").dblclick({ force: true });
+    cy.visit(`${logLink}?bookmarks=0,297`);
 
+    cy.dataCy("log-row-4").dblclick({ force: true });
     cy.dataCy("bookmark-297").click();
     cy.dataCy("log-row-297").should("be.visible");
     cy.dataCy("log-row-56").should("not.exist");
-
     cy.dataCy("bookmark-4").click();
     cy.dataCy("log-row-4").should("be.visible");
   });
 
   it("should be able to use the bookmarks bar to jump to a line when there are collapsed rows", () => {
-    cy.addFilter("pass");
+    cy.visit(`${logLink}?bookmarks=0,297&filters=100pass`);
 
     cy.dataCy("log-row-56").dblclick({ force: true });
-
     cy.dataCy("bookmark-297").click();
     cy.dataCy("log-row-297").should("be.visible");
     cy.dataCy("log-row-56").should("not.exist");
-
     cy.dataCy("bookmark-56").click();
     cy.dataCy("log-row-56").should("be.visible");
   });
+
   it("visiting a log with a selected line should jump to that line on page load", () => {
-    cy.login();
-    cy.visit(`${logLink}?selectedLine=200`);
+    cy.visit(`${logLink}?bookmarks=0,297&selectedLine=200`);
     cy.dataCy("log-row-200").should("be.visible");
   });
 });
 
 describe("expanding collapsed rows", () => {
   const logLink =
-    "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task";
-  before(() => {
+    "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task?bookmarks=0,297&filters=100evg";
+
+  beforeEach(() => {
     cy.login();
-    cy.visit(logLink);
     cy.setCookie("has-opened-drawer", "true");
+    cy.visit(logLink);
   });
 
   it("should be able to expand collapsed rows", () => {
-    // Apply a filter.
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("filter-option").click();
-    cy.dataCy("searchbar-input").type("evg{enter}");
-
     cy.dataCy("log-row-1").should("not.exist");
     cy.dataCy("log-row-2").should("not.exist");
     cy.dataCy("log-row-3").should("not.exist");
@@ -191,16 +179,23 @@ describe("expanding collapsed rows", () => {
   });
 
   it("should be able to see what rows have been expanded in the drawer", () => {
+    cy.dataCy("collapsed-row-1-4").within(() => {
+      cy.contains("All").click();
+    });
     cy.toggleDrawer();
     cy.dataCy("expanded-row-1-to-4").should("be.visible");
   });
 
   it("should be possible to re-collapse rows through the drawer", () => {
+    cy.dataCy("collapsed-row-1-4").within(() => {
+      cy.contains("All").click();
+    });
     cy.dataCy("log-row-1").should("be.visible");
     cy.dataCy("log-row-2").should("be.visible");
     cy.dataCy("log-row-3").should("be.visible");
     cy.dataCy("log-row-4").should("be.visible");
 
+    cy.toggleDrawer();
     cy.dataCy("expanded-row-1-to-4").within(() => {
       cy.get(`[aria-label="Delete range"]`).click();
     });

--- a/cypress/integration/ansiiLogs/ansii_searching.ts
+++ b/cypress/integration/ansiiLogs/ansii_searching.ts
@@ -1,10 +1,10 @@
 describe("Searching", () => {
   const logLink =
     "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task";
-  before(() => {
+  beforeEach(() => {
     cy.login();
+    cy.setCookie("has-opened-drawer", "true");
     cy.visit(logLink);
-    cy.toggleDrawer();
     cy.dataCy("searchbar-select").click();
     cy.dataCy("search-option").click();
   });
@@ -19,7 +19,6 @@ describe("Searching", () => {
   });
 
   it("searching for a term should snap the matching line to the top of the window", () => {
-    cy.dataCy("searchbar-input").clear();
     cy.dataCy("searchbar-input").type("info");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/4");
@@ -27,6 +26,8 @@ describe("Searching", () => {
   });
 
   it("should be able to specify a range of lines to search", () => {
+    cy.dataCy("searchbar-input").type("info");
+
     cy.toggleDetailsPanel(true);
     cy.dataCy("range-upper-bound").should("be.visible");
     cy.dataCy("range-upper-bound").type("25");
@@ -45,7 +46,6 @@ describe("Searching", () => {
   });
 
   it("should be able to toggle case sensitivity", () => {
-    cy.dataCy("searchbar-input").clear();
     cy.dataCy("searchbar-input").type("starting");
     cy.dataCy("search-count").should("contain.text", "1/1");
     cy.toggleDetailsPanel(true);
@@ -75,7 +75,6 @@ describe("Searching", () => {
   });
 
   it("should be able to paginate through search results", () => {
-    cy.dataCy("searchbar-input").clear();
     cy.dataCy("searchbar-input").type("info");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/4");
@@ -98,7 +97,6 @@ describe("Searching", () => {
   });
 
   it("should be able to search on filtered content", () => {
-    cy.dataCy("searchbar-input").clear();
     cy.dataCy("searchbar-input").type("spruce");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/27");

--- a/cypress/integration/ansiiLogs/ansii_searching.ts
+++ b/cypress/integration/ansiiLogs/ansii_searching.ts
@@ -5,12 +5,10 @@ describe("Searching", () => {
     cy.login();
     cy.setCookie("has-opened-drawer", "true");
     cy.visit(logLink);
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("search-option").click();
   });
 
   it("searching for a term should highlight matching words ", () => {
-    cy.dataCy("searchbar-input").type("Starting");
+    cy.addSearch("Starting");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/1");
     cy.dataCy("highlight").should("exist");
@@ -19,63 +17,33 @@ describe("Searching", () => {
   });
 
   it("searching for a term should snap the matching line to the top of the window", () => {
-    cy.dataCy("searchbar-input").type("info");
+    cy.addSearch("info");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/4");
     cy.get("[data-highlighted='true']").should("contain.text", "info");
   });
 
   it("should be able to specify a range of lines to search", () => {
-    cy.dataCy("searchbar-input").type("info");
-
-    cy.toggleDetailsPanel(true);
-    cy.dataCy("range-upper-bound").should("be.visible");
-    cy.dataCy("range-upper-bound").type("25");
-    cy.toggleDetailsPanel(false);
+    cy.addSearch("info");
+    cy.editBounds({ upper: "25" });
     cy.dataCy("search-count").should("contain.text", "1/2");
-    cy.toggleDetailsPanel(true);
-    cy.dataCy("range-lower-bound").should("be.visible");
-    cy.dataCy("range-lower-bound").type("25");
-    cy.toggleDetailsPanel(false);
+    cy.editBounds({ lower: "25" });
     cy.dataCy("search-count").should("contain.text", "1/1");
-    cy.toggleDetailsPanel(true);
-    cy.dataCy("range-lower-bound").clear();
-    cy.dataCy("range-upper-bound").clear();
-    cy.toggleDetailsPanel(false);
+    cy.clearBounds();
     cy.dataCy("search-count").should("contain.text", "1/4");
   });
 
   it("should be able to toggle case sensitivity", () => {
-    cy.dataCy("searchbar-input").type("starting");
+    cy.addSearch("starting");
     cy.dataCy("search-count").should("contain.text", "1/1");
-    cy.toggleDetailsPanel(true);
-    cy.dataCy("case-sensitive-toggle").should("be.visible");
-    cy.dataCy("case-sensitive-toggle").should(
-      "have.attr",
-      "aria-checked",
-      "false"
-    );
-    cy.dataCy("case-sensitive-toggle").click({ force: true });
-    cy.dataCy("case-sensitive-toggle").should(
-      "have.attr",
-      "aria-checked",
-      "true"
-    );
-    cy.toggleDetailsPanel(false);
+    cy.clickToggle("case-sensitive-toggle", true);
     cy.dataCy("search-count").should("contain.text", "No Matches");
-    cy.toggleDetailsPanel(true);
-    cy.dataCy("case-sensitive-toggle").click({ force: true });
-    cy.dataCy("case-sensitive-toggle").should(
-      "have.attr",
-      "aria-checked",
-      "false"
-    );
-    cy.toggleDetailsPanel(false);
+    cy.clickToggle("case-sensitive-toggle", false);
     cy.dataCy("search-count").should("contain.text", "1/1");
   });
 
   it("should be able to paginate through search results", () => {
-    cy.dataCy("searchbar-input").type("info");
+    cy.addSearch("info");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/4");
     cy.dataCy("next-button").click();
@@ -97,21 +65,12 @@ describe("Searching", () => {
   });
 
   it("should be able to search on filtered content", () => {
-    cy.dataCy("searchbar-input").type("spruce");
-    cy.dataCy("search-count").should("be.visible");
-    cy.dataCy("search-count").should("contain.text", "1/27");
-    cy.dataCy("searchbar-input").clear();
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("filter-option").click();
-    cy.dataCy("searchbar-input").type("Starting");
-    cy.dataCy("searchbar-input").type("{enter}");
+    cy.addFilter("installation");
     cy.get("[data-cy^='collapsed-row-']").should("exist");
-    cy.get("[data-cy^='collapsed-row-']").should("have.length", 1);
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("search-option").click();
-    cy.dataCy("searchbar-input").clear();
-    cy.dataCy("searchbar-input").type("Spruce");
+    cy.get("[data-cy^='collapsed-row-']").should("have.length", 3);
+
+    cy.addSearch("info");
     cy.dataCy("search-count").should("be.visible");
-    cy.dataCy("search-count").should("contain.text", "1/1");
+    cy.dataCy("search-count").should("contain.text", "1/2");
   });
 });

--- a/cypress/integration/externalLinks.ts
+++ b/cypress/integration/externalLinks.ts
@@ -1,6 +1,6 @@
 describe("External Links", () => {
   describe("should render links to external pages when viewing an evergreen task log", () => {
-    before(() => {
+    beforeEach(() => {
       cy.login();
       cy.visit(
         "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task"
@@ -33,7 +33,7 @@ describe("External Links", () => {
     });
   });
   describe("should render links to external pages when viewing an evergreen test log", () => {
-    before(() => {
+    beforeEach(() => {
       cy.login();
       cy.visit(
         "/test/spruce_ubuntu1604_check_codegen_d54e2c6ede60e004c48d3c4d996c59579c7bbd1f_22_03_02_15_41_35/0/JustAFakeTestInALonelyWorld"
@@ -68,7 +68,7 @@ describe("External Links", () => {
   describe("should render links to external pages when viewing a resmoke test log", () => {
     const taskID =
       "mongodb_mongo_master_rhel80_debug_v4ubsan_all_feature_flags_experimental_concurrency_sharded_with_stepdowns_and_balancer_4_linux_enterprise_361789ed8a613a2dc0335a821ead0ab6205fbdaa_22_09_21_02_53_24";
-    before(() => {
+    beforeEach(() => {
       cy.login();
       cy.visit(
         "/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab"
@@ -99,7 +99,7 @@ describe("External Links", () => {
         `http://localhost:8080/build/7e208050e166b1a9025c817b67eee48d`
       );
     });
-    it("should render a link to the task page", () => {
+    it("should render a link to the Evergreen task page", () => {
       cy.contains("Task Page").should("be.visible");
       cy.contains("Task Page").should(
         "have.attr",

--- a/cypress/integration/resmokeLogs/resmoke_filtering.ts
+++ b/cypress/integration/resmokeLogs/resmoke_filtering.ts
@@ -4,7 +4,7 @@ describe("Filtering", () => {
 
   describe("Applying filters", () => {
     describe("Basic filtering", () => {
-      before(() => {
+      beforeEach(() => {
         cy.login();
         cy.setCookie("has-opened-drawer", "true");
         cy.visit(logLink);
@@ -35,57 +35,71 @@ describe("Filtering", () => {
       const filter2 = "metadata";
 
       describe("filtering mode is AND", () => {
-        before(() => {
+        beforeEach(() => {
           cy.login();
-          cy.visit(`${logLink}/?filterLogic=and`);
-          cy.dataCy("clear-bookmarks").click();
         });
 
         it("should be able to apply two default filters (case insensitive, exact match)", () => {
+          cy.visit(`${logLink}?filterLogic=and`);
           cy.addFilter(filter1);
           cy.addFilter(filter2);
           cy.location("search").should(
-            "equal",
-            `?filterLogic=and&filters=100${filter1},100${filter2}`
+            "contain",
+            `filters=100${filter1},100${filter2}`
           );
-
-          cy.get("[data-cy^='log-row-']").each(($el) => {
-            cy.wrap($el).contains(filter1, { matchCase: false });
-            cy.wrap($el).contains(filter2, { matchCase: false });
-          });
+          cy.get("[data-cy^='log-row-']")
+            .not("[data-cy='log-row-0']")
+            .not("[data-cy='log-row-11079']")
+            .each(($el) => {
+              cy.wrap($el).contains(filter1, { matchCase: false });
+              cy.wrap($el).contains(filter2, { matchCase: false });
+            });
         });
 
         it("should be able to toggle case sensitivity", () => {
+          cy.visit(
+            `${logLink}?filterLogic=and&filters=100${filter1},100${filter2}`
+          );
           cy.dataCy(`filter-${filter1}`).within(() => {
             cy.contains("Sensitive").click();
           });
           cy.location("search").should(
-            "equal",
-            `?filterLogic=and&filters=110${filter1},100${filter2}`
+            "contain",
+            `filters=110${filter1},100${filter2}`
           );
-
-          cy.get("[data-cy^='log-row-']").each(($el) => {
-            cy.wrap($el).contains(filter1, { matchCase: true });
-            cy.wrap($el).contains(filter2, { matchCase: false });
-          });
+          cy.get("[data-cy^='log-row-']")
+            .not("[data-cy='log-row-0']")
+            .not("[data-cy='log-row-11079']")
+            .each(($el) => {
+              cy.wrap($el).contains(filter1, { matchCase: true });
+              cy.wrap($el).contains(filter2, { matchCase: false });
+            });
         });
 
         it("should be able to toggle inverse matching", () => {
+          cy.visit(
+            `${logLink}?filterLogic=and&filters=110${filter1},100${filter2}`
+          );
           cy.dataCy(`filter-${filter2}`).within(() => {
             cy.contains("Inverse").click();
           });
           cy.location("search").should(
-            "equal",
-            `?filterLogic=and&filters=110${filter1},101${filter2}`
+            "contain",
+            `filters=110${filter1},101${filter2}`
           );
-
-          cy.get("[data-cy^='log-row-']").each(($el) => {
-            cy.wrap($el).contains(filter1, { matchCase: true });
-            cy.wrap($el).should("not.contain.text", filter2);
-          });
+          cy.get("[data-cy^='log-row-']")
+            .not("[data-cy='log-row-0']")
+            .not("[data-cy='log-row-11079']")
+            .each(($el) => {
+              cy.wrap($el).contains(filter1, { matchCase: true });
+              cy.wrap($el).should("not.contain.text", filter2);
+            });
         });
 
         it("should be able to toggle visibility", () => {
+          cy.visit(
+            `${logLink}?filterLogic=and&filters=110${filter1},101${filter2}`
+          );
           cy.dataCy(`filter-${filter1}`).within(() => {
             cy.get(`[aria-label="Hide filter"]`).click();
           });
@@ -93,77 +107,90 @@ describe("Filtering", () => {
             cy.get(`[aria-label="Hide filter"]`).click();
           });
           cy.location("search").should(
-            "equal",
-            `?filterLogic=and&filters=010${filter1},001${filter2}`
+            "contain",
+            `filters=010${filter1},001${filter2}`
           );
-
           cy.get("[data-cy^='collapsed-row-']").should("not.exist");
         });
       });
 
       describe("filtering mode is OR", () => {
-        before(() => {
+        beforeEach(() => {
           cy.login();
-          cy.visit(`${logLink}/?filterLogic=or`);
-          cy.dataCy("clear-bookmarks").click();
         });
 
         it("should be able to apply two default filters (case insensitive, exact match)", () => {
+          cy.visit(`${logLink}?filterLogic=or`);
           cy.addFilter(filter1);
           cy.addFilter(filter2);
           cy.location("search").should(
-            "equal",
-            `?filterLogic=or&filters=100${filter1},100${filter2}`
+            "contain",
+            `filters=100${filter1},100${filter2}`
           );
-
-          cy.get("[data-cy^='log-row-']").each(($el) => {
-            cy.wrap($el)
-              .invoke("text")
-              .should("match", /NETWORK|metadata/i);
-          });
+          cy.get("[data-cy^='log-row-']")
+            .not("[data-cy='log-row-0']")
+            .not("[data-cy='log-row-11079']")
+            .each(($el) => {
+              cy.wrap($el)
+                .invoke("text")
+                .should("match", /NETWORK|metadata/i);
+            });
         });
 
         it("should be able to toggle case sensitivity", () => {
+          cy.visit(
+            `${logLink}?filterLogic=or&filters=100${filter1},100${filter2}`
+          );
           cy.dataCy(`filter-${filter1}`).within(() => {
             cy.contains("Sensitive").click();
           });
           cy.location("search").should(
-            "equal",
-            `?filterLogic=or&filters=110${filter1},100${filter2}`
+            "contain",
+            `filters=110${filter1},100${filter2}`
           );
-
-          cy.get("[data-cy^='log-row-']").each(($el) => {
-            cy.wrap($el)
-              .invoke("text")
-              .should(
-                "satisfy",
-                (text: string) =>
-                  text.match(/NETWORK/) || text.match(/metadata/i)
-              );
-          });
+          cy.get("[data-cy^='log-row-']")
+            .not("[data-cy='log-row-0']")
+            .not("[data-cy='log-row-11079']")
+            .each(($el) => {
+              cy.wrap($el)
+                .invoke("text")
+                .should(
+                  "satisfy",
+                  (text: string) =>
+                    text.match(/NETWORK/) || text.match(/metadata/i)
+                );
+            });
         });
 
         it("should be able to toggle inverse matching", () => {
+          cy.visit(
+            `${logLink}?filterLogic=or&filters=110${filter1},100${filter2}`
+          );
           cy.dataCy(`filter-${filter2}`).within(() => {
             cy.contains("Inverse").click();
           });
           cy.location("search").should(
-            "equal",
-            `?filterLogic=or&filters=110${filter1},101${filter2}`
+            "contain",
+            `filters=110${filter1},101${filter2}`
           );
-
-          cy.get("[data-cy^='log-row-']").each(($el) => {
-            cy.wrap($el)
-              .invoke("text")
-              .should(
-                "satisfy",
-                (text: string) =>
-                  text.match(/NETWORK/) || !text.match(/metadata/i)
-              );
-          });
+          cy.get("[data-cy^='log-row-']")
+            .not("[data-cy='log-row-0']")
+            .not("[data-cy='log-row-11079']")
+            .each(($el) => {
+              cy.wrap($el)
+                .invoke("text")
+                .should(
+                  "satisfy",
+                  (text: string) =>
+                    text.match(/NETWORK/) || !text.match(/metadata/i)
+                );
+            });
         });
 
         it("should be able to toggle visibility", () => {
+          cy.visit(
+            `${logLink}?filterLogic=or&filters=110${filter1},101${filter2}`
+          );
           cy.dataCy(`filter-${filter1}`).within(() => {
             cy.get(`[aria-label="Hide filter"]`).click();
           });
@@ -171,10 +198,9 @@ describe("Filtering", () => {
             cy.get(`[aria-label="Hide filter"]`).click();
           });
           cy.location("search").should(
-            "equal",
-            `?filterLogic=or&filters=010${filter1},001${filter2}`
+            "contain",
+            `filters=010${filter1},001${filter2}`
           );
-
           cy.get("[data-cy^='collapsed-row-']").should("not.exist");
         });
       });
@@ -182,37 +208,41 @@ describe("Filtering", () => {
   });
 
   describe("Deleting and editing filters", () => {
-    before(() => {
+    beforeEach(() => {
       cy.login();
       cy.visit(logLink);
-      cy.dataCy("clear-bookmarks").click();
-      cy.location("search").should("equal", "");
     });
 
     it("should be able to edit a filter", () => {
       cy.addFilter("notarealfilter");
-      cy.location("search").should("equal", "?filters=100notarealfilter");
+      cy.location("search").should("contain", "filters=100notarealfilter");
 
-      cy.get("[data-cy^='log-row-']").should("not.exist");
+      cy.get("[data-cy^='log-row-']")
+        .not("[data-cy='log-row-0']")
+        .not("[data-cy='log-row-11079']")
+        .should("not.exist");
 
       cy.dataCy("filter-notarealfilter").within(() => {
         cy.get(`[aria-label="Edit filter"]`).click();
       });
       cy.dataCy("edit-filter-name").clear().type("REPL_HB");
       cy.contains("button", "Apply").click();
-      cy.location("search").should("equal", "?filters=100REPL_HB");
+      cy.location("search").should("contain", "filters=100REPL_HB");
 
-      cy.get("[data-cy^='log-row-']").each(($el) => {
-        cy.wrap($el).contains("REPL_HB", { matchCase: false });
-      });
+      cy.get("[data-cy^='log-row-']")
+        .not("[data-cy='log-row-0']")
+        .not("[data-cy='log-row-11079']")
+        .each(($el) => {
+          cy.wrap($el).contains("REPL_HB", { matchCase: false });
+        });
     });
 
     it("should be able to delete a filter", () => {
+      cy.addFilter("REPL_HB");
       cy.dataCy("filter-REPL_HB").within(() => {
         cy.get(`[aria-label="Delete filter"]`).click();
       });
-      cy.location("search").should("equal", "");
-
+      cy.location("search").should("not.contain", "filters");
       cy.get("[data-cy^='collapsed-row-']").should("not.exist");
     });
   });

--- a/cypress/integration/resmokeLogs/resmoke_filtering.ts
+++ b/cypress/integration/resmokeLogs/resmoke_filtering.ts
@@ -1,6 +1,6 @@
 describe("Filtering", () => {
   const logLink =
-    "/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab";
+    "/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e17b99558fd9c5e2faf70a00d15d";
 
   describe("Applying filters", () => {
     describe("Basic filtering", () => {
@@ -17,7 +17,7 @@ describe("Filtering", () => {
         cy.dataCy("log-row-6").dblclick();
         cy.location("search").should(
           "equal",
-          "?bookmarks=0,6,11079&selectedLine=5"
+          "?bookmarks=0,6,130&selectedLine=5"
         );
         // Apply a filter that doesn't satisfy any log line.
         cy.addFilter("notarealfilter");
@@ -25,14 +25,14 @@ describe("Filtering", () => {
         cy.get("[data-cy^='log-row-']").each(($el) => {
           cy.wrap($el)
             .should("have.attr", "data-cy")
-            .and("match", /log-row-(0|5|6|11079)/);
+            .and("match", /log-row-(0|5|6|130)/);
         });
       });
     });
 
     describe("Advanced filtering", () => {
-      const filter1 = "NETWORK";
-      const filter2 = "metadata";
+      const filter1 = "deleted";
+      const filter2 = "session";
 
       describe("filtering mode is AND", () => {
         beforeEach(() => {
@@ -48,8 +48,7 @@ describe("Filtering", () => {
             `filters=100${filter1},100${filter2}`
           );
           cy.get("[data-cy^='log-row-']")
-            .not("[data-cy='log-row-0']")
-            .not("[data-cy='log-row-11079']")
+            .not("[data-bookmarked=true]")
             .each(($el) => {
               cy.wrap($el).contains(filter1, { matchCase: false });
               cy.wrap($el).contains(filter2, { matchCase: false });
@@ -68,8 +67,7 @@ describe("Filtering", () => {
             `filters=110${filter1},100${filter2}`
           );
           cy.get("[data-cy^='log-row-']")
-            .not("[data-cy='log-row-0']")
-            .not("[data-cy='log-row-11079']")
+            .not("[data-bookmarked=true]")
             .each(($el) => {
               cy.wrap($el).contains(filter1, { matchCase: true });
               cy.wrap($el).contains(filter2, { matchCase: false });
@@ -88,8 +86,7 @@ describe("Filtering", () => {
             `filters=110${filter1},101${filter2}`
           );
           cy.get("[data-cy^='log-row-']")
-            .not("[data-cy='log-row-0']")
-            .not("[data-cy='log-row-11079']")
+            .not("[data-bookmarked='true']")
             .each(($el) => {
               cy.wrap($el).contains(filter1, { matchCase: true });
               cy.wrap($el).should("not.contain.text", filter2);
@@ -128,12 +125,11 @@ describe("Filtering", () => {
             `filters=100${filter1},100${filter2}`
           );
           cy.get("[data-cy^='log-row-']")
-            .not("[data-cy='log-row-0']")
-            .not("[data-cy='log-row-11079']")
+            .not("[data-bookmarked=true]")
             .each(($el) => {
               cy.wrap($el)
                 .invoke("text")
-                .should("match", /NETWORK|metadata/i);
+                .should("match", /deleted|session/i);
             });
         });
 
@@ -149,15 +145,14 @@ describe("Filtering", () => {
             `filters=110${filter1},100${filter2}`
           );
           cy.get("[data-cy^='log-row-']")
-            .not("[data-cy='log-row-0']")
-            .not("[data-cy='log-row-11079']")
+            .not("[data-bookmarked=true]")
             .each(($el) => {
               cy.wrap($el)
                 .invoke("text")
                 .should(
                   "satisfy",
                   (text: string) =>
-                    text.match(/NETWORK/) || text.match(/metadata/i)
+                    text.match(/deleted/) || text.match(/session/i)
                 );
             });
         });
@@ -174,15 +169,14 @@ describe("Filtering", () => {
             `filters=110${filter1},101${filter2}`
           );
           cy.get("[data-cy^='log-row-']")
-            .not("[data-cy='log-row-0']")
-            .not("[data-cy='log-row-11079']")
+            .not("[data-bookmarked=true]")
             .each(($el) => {
               cy.wrap($el)
                 .invoke("text")
                 .should(
                   "satisfy",
                   (text: string) =>
-                    text.match(/NETWORK/) || !text.match(/metadata/i)
+                    text.match(/deleted/) || !text.match(/session/i)
                 );
             });
         });
@@ -218,28 +212,26 @@ describe("Filtering", () => {
       cy.location("search").should("contain", "filters=100notarealfilter");
 
       cy.get("[data-cy^='log-row-']")
-        .not("[data-cy='log-row-0']")
-        .not("[data-cy='log-row-11079']")
+        .not("[data-bookmarked=true]")
         .should("not.exist");
 
       cy.dataCy("filter-notarealfilter").within(() => {
         cy.get(`[aria-label="Edit filter"]`).click();
       });
-      cy.dataCy("edit-filter-name").clear().type("REPL_HB");
+      cy.dataCy("edit-filter-name").clear().type("session");
       cy.contains("button", "Apply").click();
-      cy.location("search").should("contain", "filters=100REPL_HB");
+      cy.location("search").should("contain", "filters=100session");
 
       cy.get("[data-cy^='log-row-']")
-        .not("[data-cy='log-row-0']")
-        .not("[data-cy='log-row-11079']")
+        .not("[data-bookmarked=true]")
         .each(($el) => {
-          cy.wrap($el).contains("REPL_HB", { matchCase: false });
+          cy.wrap($el).contains("session", { matchCase: false });
         });
     });
 
     it("should be able to delete a filter", () => {
-      cy.addFilter("REPL_HB");
-      cy.dataCy("filter-REPL_HB").within(() => {
+      cy.addFilter("session");
+      cy.dataCy("filter-session").within(() => {
         cy.get(`[aria-label="Delete filter"]`).click();
       });
       cy.location("search").should("not.contain", "filters");

--- a/cypress/integration/resmokeLogs/resmoke_filtering.ts
+++ b/cypress/integration/resmokeLogs/resmoke_filtering.ts
@@ -12,16 +12,13 @@ describe("Filtering", () => {
       });
 
       it("should not collapse bookmarks and selected line", () => {
-        // Bookmark and select a line, with the expectation that they won't be collapsed by the filter.
         cy.dataCy("log-link-5").click();
         cy.dataCy("log-row-6").dblclick();
         cy.location("search").should(
           "equal",
           "?bookmarks=0,6,130&selectedLine=5"
         );
-        // Apply a filter that doesn't satisfy any log line.
-        cy.addFilter("notarealfilter");
-        // Matched elements should be one of the bookmarked or selected values
+        cy.addFilter("doesNotMatchAnything");
         cy.get("[data-cy^='log-row-']").each(($el) => {
           cy.wrap($el)
             .should("have.attr", "data-cy")
@@ -202,26 +199,21 @@ describe("Filtering", () => {
   });
 
   describe("Deleting and editing filters", () => {
+    const filter = "doesNotMatchAnything";
+
     beforeEach(() => {
       cy.login();
-      cy.visit(logLink);
+      cy.visit(`${logLink}?filters=100${filter}`);
+      cy.get("[data-cy^='collapsed-row-']").should("exist");
     });
 
     it("should be able to edit a filter", () => {
-      cy.addFilter("notarealfilter");
-      cy.location("search").should("contain", "filters=100notarealfilter");
-
-      cy.get("[data-cy^='log-row-']")
-        .not("[data-bookmarked=true]")
-        .should("not.exist");
-
-      cy.dataCy("filter-notarealfilter").within(() => {
+      cy.dataCy(`filter-${filter}`).within(() => {
         cy.get(`[aria-label="Edit filter"]`).click();
       });
       cy.dataCy("edit-filter-name").clear().type("session");
       cy.contains("button", "Apply").click();
       cy.location("search").should("contain", "filters=100session");
-
       cy.get("[data-cy^='log-row-']")
         .not("[data-bookmarked=true]")
         .each(($el) => {
@@ -230,8 +222,7 @@ describe("Filtering", () => {
     });
 
     it("should be able to delete a filter", () => {
-      cy.addFilter("session");
-      cy.dataCy("filter-session").within(() => {
+      cy.dataCy(`filter-${filter}`).within(() => {
         cy.get(`[aria-label="Delete filter"]`).click();
       });
       cy.location("search").should("not.contain", "filters");

--- a/cypress/integration/resmokeLogs/resmoke_highlighting.ts
+++ b/cypress/integration/resmokeLogs/resmoke_highlighting.ts
@@ -2,44 +2,51 @@ describe("Highlighting", () => {
   const logLink =
     "/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab";
 
-  before(() => {
+  beforeEach(() => {
     cy.login();
+    cy.setCookie("has-opened-drawer", "true");
     cy.visit(logLink);
-    cy.toggleDrawer();
     cy.dataCy("searchbar-select").click();
     cy.dataCy("highlight-option").click();
   });
 
   it("applying a highlight should highlight matching words ", () => {
-    cy.dataCy("searchbar-input").type("ShardedClusterFixture:job0:mongos0 ");
-    cy.dataCy("searchbar-input").type("{enter}");
+    cy.dataCy("searchbar-input").type(
+      "ShardedClusterFixture:job0:mongos0{enter}"
+    );
     cy.dataCy("highlight").should("exist");
     cy.dataCy("highlight").should("have.length", 1);
     cy.dataCy("highlight").should(
       "contain.text",
-      "ShardedClusterFixture:job0:mongos0 "
+      "ShardedClusterFixture:job0:mongos0"
     );
   });
 
   it("applying a search to a highlighted line should not overwrite an already highlighted term if the search matches the highlight", () => {
-    cy.dataCy("searchbar-input").clear();
+    cy.dataCy("searchbar-input").type(
+      "ShardedClusterFixture:job0:mongos0{enter}"
+    );
+
     cy.dataCy("searchbar-select").click();
     cy.dataCy("search-option").click();
-    cy.dataCy("searchbar-input").type("ShardedClusterFixture:job0:mongos0 ");
-    cy.dataCy("searchbar-input").type("{enter}");
+    cy.dataCy("searchbar-input").type(
+      "ShardedClusterFixture:job0:mongos0{enter}"
+    );
+
     cy.dataCy("highlight").should("exist");
     cy.dataCy("highlight").should("have.length", 1);
     cy.dataCy("highlight").should(
       "contain.text",
-      "ShardedClusterFixture:job0:mongos0 "
+      "ShardedClusterFixture:job0:mongos0"
     );
   });
   it("should highlight other terms in the log if the search term does not match the highlight", () => {
-    cy.dataCy("searchbar-input").clear();
     cy.dataCy("searchbar-input").type(
-      "ShardedClusterFixture:job0:shard0:node1"
+      "ShardedClusterFixture:job0:mongos0{enter}"
     );
-    cy.dataCy("searchbar-input").type("{enter}");
+    cy.dataCy("searchbar-input").type(
+      "ShardedClusterFixture:job0:shard0:node1{enter}"
+    );
     cy.dataCy("highlight").should("exist");
     cy.dataCy("highlight").should("have.length", 2);
     cy.dataCy("highlight").each(($el) => {
@@ -51,16 +58,11 @@ describe("Highlighting", () => {
         );
     });
   });
-  it("clearing a search should not clear a highlight", () => {
-    cy.dataCy("searchbar-input").clear();
-    cy.dataCy("highlight").should("exist");
-    cy.dataCy("highlight").should("have.length", 1);
-    cy.dataCy("highlight").should(
-      "contain.text",
-      "ShardedClusterFixture:job0:mongos0"
-    );
-  });
   it("removing a highlight from the sidenav should remove the highlight", () => {
+    cy.dataCy("searchbar-input").type(
+      "ShardedClusterFixture:job0:shard0:node1{enter}"
+    );
+    cy.dataCy("highlight").should("exist");
     cy.toggleDrawer();
     cy.dataCy("delete-highlight-button").should("be.visible");
     cy.dataCy("delete-highlight-button").click();

--- a/cypress/integration/resmokeLogs/resmoke_highlighting.ts
+++ b/cypress/integration/resmokeLogs/resmoke_highlighting.ts
@@ -6,47 +6,31 @@ describe("Highlighting", () => {
     cy.login();
     cy.setCookie("has-opened-drawer", "true");
     cy.visit(logLink);
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("highlight-option").click();
   });
 
   it("applying a highlight should highlight matching words ", () => {
-    cy.dataCy("searchbar-input").type(
-      "ShardedClusterFixture:job0:mongos0{enter}"
-    );
+    cy.addHighlight("ShardedClusterFixture:job0:mongos0 ");
     cy.dataCy("highlight").should("exist");
     cy.dataCy("highlight").should("have.length", 1);
     cy.dataCy("highlight").should(
       "contain.text",
-      "ShardedClusterFixture:job0:mongos0"
+      "ShardedClusterFixture:job0:mongos0 "
     );
   });
 
   it("applying a search to a highlighted line should not overwrite an already highlighted term if the search matches the highlight", () => {
-    cy.dataCy("searchbar-input").type(
-      "ShardedClusterFixture:job0:mongos0{enter}"
-    );
-
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("search-option").click();
-    cy.dataCy("searchbar-input").type(
-      "ShardedClusterFixture:job0:mongos0{enter}"
-    );
-
+    cy.addHighlight("ShardedClusterFixture:job0:mongos0 ");
+    cy.addSearch("ShardedClusterFixture:job0:mongos0 ");
     cy.dataCy("highlight").should("exist");
     cy.dataCy("highlight").should("have.length", 1);
     cy.dataCy("highlight").should(
       "contain.text",
-      "ShardedClusterFixture:job0:mongos0"
+      "ShardedClusterFixture:job0:mongos0 "
     );
   });
   it("should highlight other terms in the log if the search term does not match the highlight", () => {
-    cy.dataCy("searchbar-input").type(
-      "ShardedClusterFixture:job0:mongos0{enter}"
-    );
-    cy.dataCy("searchbar-input").type(
-      "ShardedClusterFixture:job0:shard0:node1{enter}"
-    );
+    cy.addHighlight("ShardedClusterFixture:job0:mongos0 ");
+    cy.addSearch("ShardedClusterFixture:job0:shard0:node1");
     cy.dataCy("highlight").should("exist");
     cy.dataCy("highlight").should("have.length", 2);
     cy.dataCy("highlight").each(($el) => {
@@ -58,10 +42,8 @@ describe("Highlighting", () => {
         );
     });
   });
-  it("removing a highlight from the sidenav should remove the highlight", () => {
-    cy.dataCy("searchbar-input").type(
-      "ShardedClusterFixture:job0:shard0:node1{enter}"
-    );
+  it("removing a highlight from the side panel should remove the highlight", () => {
+    cy.addHighlight("ShardedClusterFixture:job0:shard0:node1");
     cy.dataCy("highlight").should("exist");
     cy.toggleDrawer();
     cy.dataCy("delete-highlight-button").should("be.visible");

--- a/cypress/integration/resmokeLogs/resmoke_logView.ts
+++ b/cypress/integration/resmokeLogs/resmoke_logView.ts
@@ -1,10 +1,10 @@
 describe("Basic resmoke log view", () => {
   const logLink =
     "/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab";
-  before(() => {
+  beforeEach(() => {
     cy.login();
-    cy.visit(logLink);
     cy.setCookie("has-opened-drawer", "true");
+    cy.visit(logLink);
   });
 
   it("should render resmoke lines", () => {
@@ -23,10 +23,9 @@ describe("Basic resmoke log view", () => {
     });
   });
   it("long lines with wrapping turned on should fit on screen", () => {
-    cy.clickToggle("wrap-toggle", true); // Turn wrap on.
+    cy.clickToggle("wrap-toggle", true);
     cy.dataCy("log-row-16").should("be.visible");
     cy.dataCy("log-row-16").isContainedInViewport();
-    cy.clickToggle("wrap-toggle", false); // Turn wrap off.
   });
   it("should still allow horizontal scrolling when there are few logs on screen", () => {
     cy.dataCy("searchbar-select").click();
@@ -51,10 +50,11 @@ describe("Resmoke syntax highlighting", () => {
   };
   const logLink =
     "/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab";
-  before(() => {
+
+  beforeEach(() => {
     cy.login();
-    cy.visit(logLink);
     cy.setCookie("has-opened-drawer", "true");
+    cy.visit(logLink);
   });
   it("should not color non resmoke log lines", () => {
     cy.dataCy("log-row-0").within(() => {
@@ -69,7 +69,6 @@ describe("Resmoke syntax highlighting", () => {
     cy.dataCy("log-row-20").within(() => {
       cy.dataCy("resmoke-row").should("have.css", "color", colors.blue);
     });
-
     cy.dataCy("log-row-21").within(() => {
       cy.dataCy("resmoke-row").should("have.css", "color", colors.blue);
     });
@@ -87,13 +86,14 @@ describe("Resmoke syntax highlighting", () => {
     });
   });
 });
+
 describe("Bookmarking and selecting lines", () => {
   const logLink =
     "/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab";
-  before(() => {
+  beforeEach(() => {
     cy.login();
-    cy.visit(logLink);
     cy.setCookie("has-opened-drawer", "true");
+    cy.visit(logLink);
   });
 
   it("should default to bookmarking 0 and the last log line on load", () => {
@@ -148,6 +148,7 @@ describe("Bookmarking and selecting lines", () => {
   });
 
   it("should be able to clear bookmarks", () => {
+    cy.location("search").should("equal", "?bookmarks=0,11079");
     cy.dataCy("clear-bookmarks").click();
     cy.location("search").should("equal", "");
   });
@@ -156,18 +157,13 @@ describe("Bookmarking and selecting lines", () => {
 describe("Jump to line", () => {
   const logLink =
     "/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab";
-  before(() => {
+  beforeEach(() => {
     cy.login();
-    cy.visit(logLink);
-  });
-
-  it("should default to bookmarking 0 and the last log line on load", () => {
-    cy.location("search").should("equal", "?bookmarks=0,11079");
-    cy.dataCy("bookmark-list").should("contain", "0");
-    cy.dataCy("bookmark-list").should("contain", "11079");
+    cy.setCookie("has-opened-drawer", "true");
   });
 
   it("should be able to use the bookmarks bar to jump to a line when there are no collapsed rows", () => {
+    cy.visit(`${logLink}?bookmarks=0,11079`);
     cy.dataCy("log-row-4").dblclick({ force: true });
 
     cy.dataCy("bookmark-11079").click();
@@ -179,7 +175,7 @@ describe("Jump to line", () => {
   });
 
   it("should be able to use the bookmarks bar to jump to a line when there are collapsed rows", () => {
-    cy.addFilter("repl_hb");
+    cy.visit(`${logLink}?bookmarks=0,11079&filters=100repl_hb`);
 
     cy.dataCy("log-row-30").dblclick({ force: true });
 
@@ -190,27 +186,23 @@ describe("Jump to line", () => {
     cy.dataCy("bookmark-30").click();
     cy.dataCy("log-row-30").should("be.visible");
   });
+
   it("visiting a log with a selected line should jump to that line on page load", () => {
-    cy.visit(`${logLink}?selectedLine=200`);
+    cy.visit(`${logLink}?bookmarks=0,11079&selectedLine=200`);
     cy.dataCy("log-row-200").should("be.visible");
   });
 });
 
 describe("expanding collapsed rows", () => {
   const logLink =
-    "/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab";
-  before(() => {
+    "/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab?bookmarks=0,11079&filters=100ShardedClusterFixture%253Ajob0";
+  beforeEach(() => {
     cy.login();
     cy.setCookie("has-opened-drawer", "true");
     cy.visit(logLink);
   });
 
   it("should be able to expand collapsed rows", () => {
-    // Apply a filter.
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("filter-option").click();
-    cy.dataCy("searchbar-input").type("ShardedClusterFixture:job0{enter}");
-
     cy.dataCy("log-row-1").should("not.exist");
     cy.dataCy("log-row-2").should("not.exist");
     cy.dataCy("log-row-3").should("not.exist");
@@ -226,15 +218,23 @@ describe("expanding collapsed rows", () => {
   });
 
   it("should be able to see what rows have been expanded in the drawer", () => {
+    cy.dataCy("collapsed-row-1-3").within(() => {
+      cy.contains("All").click();
+    });
+
     cy.toggleDrawer();
     cy.dataCy("expanded-row-1-to-3").should("be.visible");
   });
 
   it("should be possible to re-collapse rows through the drawer", () => {
+    cy.dataCy("collapsed-row-1-3").within(() => {
+      cy.contains("All").click();
+    });
     cy.dataCy("log-row-1").should("be.visible");
     cy.dataCy("log-row-2").should("be.visible");
     cy.dataCy("log-row-3").should("be.visible");
 
+    cy.toggleDrawer();
     cy.dataCy("expanded-row-1-to-3").within(() => {
       cy.get(`[aria-label="Delete range"]`).click();
     });
@@ -245,7 +245,7 @@ describe("expanding collapsed rows", () => {
 describe("pretty print", () => {
   const logLink =
     "/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab";
-  before(() => {
+  beforeEach(() => {
     cy.login();
     cy.setCookie("has-opened-drawer", "true");
     cy.setCookie("pretty-print-bookmarks", "true");

--- a/cypress/integration/resmokeLogs/resmoke_logView.ts
+++ b/cypress/integration/resmokeLogs/resmoke_logView.ts
@@ -28,15 +28,12 @@ describe("Basic resmoke log view", () => {
     cy.dataCy("log-row-16").isContainedInViewport();
   });
   it("should still allow horizontal scrolling when there are few logs on screen", () => {
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("filter-option").click();
-    cy.dataCy("searchbar-input").type("Putting spruce/{enter}");
+    cy.addFilter("Putting spruce/");
     cy.get(".ReactVirtualized__Grid").should(
       "have.css",
       "overflow-x",
       "scroll"
     );
-    // scroll to the right
     cy.get(".ReactVirtualized__Grid").scrollTo("right");
   });
 });
@@ -56,7 +53,7 @@ describe("Resmoke syntax highlighting", () => {
     cy.setCookie("has-opened-drawer", "true");
     cy.visit(logLink);
   });
-  it("should not color non resmoke log lines", () => {
+  it("should not color non-resmoke log lines", () => {
     cy.dataCy("log-row-0").within(() => {
       cy.dataCy("resmoke-row").should("have.css", "color", colors.black);
     });
@@ -108,16 +105,17 @@ describe("Bookmarking and selecting lines", () => {
     cy.dataCy("bookmark-list").should("contain", "0");
     cy.dataCy("bookmark-list").should("contain", "4");
     cy.dataCy("bookmark-list").should("contain", "11079");
-
     cy.dataCy("log-row-4").dblclick();
+    cy.location("search").should("equal", "?bookmarks=0,11079");
     cy.dataCy("bookmark-list").should("not.contain", "4");
   });
 
-  it("should be able to select and unselect lines", () => {
+  it("should be able to set and unset the share line", () => {
     cy.dataCy("log-link-5").click();
     cy.location("search").should("equal", "?bookmarks=0,11079&selectedLine=5");
+    cy.dataCy("bookmark-list").should("contain", "0");
     cy.dataCy("bookmark-list").should("contain", "5");
-
+    cy.dataCy("bookmark-list").should("contain", "11079");
     cy.dataCy("log-link-5").click();
     cy.location("search").should("equal", "?bookmarks=0,11079");
     cy.dataCy("bookmark-list").should("not.contain", "5");
@@ -168,7 +166,7 @@ describe("Jump to line", () => {
 
     cy.dataCy("bookmark-11079").click();
     cy.dataCy("log-row-11079").should("be.visible");
-    cy.dataCy("log-row-56").should("not.exist");
+    cy.dataCy("log-row-4").should("not.exist");
 
     cy.dataCy("bookmark-4").click();
     cy.dataCy("log-row-4").should("be.visible");
@@ -176,7 +174,6 @@ describe("Jump to line", () => {
 
   it("should be able to use the bookmarks bar to jump to a line when there are collapsed rows", () => {
     cy.visit(`${logLink}?bookmarks=0,11079&filters=100repl_hb`);
-
     cy.dataCy("log-row-30").dblclick({ force: true });
 
     cy.dataCy("bookmark-11079").click();
@@ -221,7 +218,6 @@ describe("expanding collapsed rows", () => {
     cy.dataCy("collapsed-row-1-3").within(() => {
       cy.contains("All").click();
     });
-
     cy.toggleDrawer();
     cy.dataCy("expanded-row-1-to-3").should("be.visible");
   });
@@ -230,9 +226,7 @@ describe("expanding collapsed rows", () => {
     cy.dataCy("collapsed-row-1-3").within(() => {
       cy.contains("All").click();
     });
-    cy.dataCy("log-row-1").should("be.visible");
-    cy.dataCy("log-row-2").should("be.visible");
-    cy.dataCy("log-row-3").should("be.visible");
+    cy.dataCy("collapsed-row-1-3").should("not.exist");
 
     cy.toggleDrawer();
     cy.dataCy("expanded-row-1-to-3").within(() => {

--- a/cypress/integration/resmokeLogs/resmoke_searching.ts
+++ b/cypress/integration/resmokeLogs/resmoke_searching.ts
@@ -6,12 +6,10 @@ describe("Searching", () => {
     cy.login();
     cy.setCookie("has-opened-drawer", "true");
     cy.visit(logLink);
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("search-option").click();
   });
 
   it("searching for a term should highlight matching words ", () => {
-    cy.dataCy("searchbar-input").type("ShardedClusterFixture:job0:mongos0 ");
+    cy.addSearch("ShardedClusterFixture:job0:mongos0 ");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/1");
     cy.dataCy("highlight").should("exist");
@@ -23,62 +21,33 @@ describe("Searching", () => {
   });
 
   it("searching for a term should snap the matching line to the top of the window", () => {
-    cy.dataCy("searchbar-input").type("REPL_HB");
+    cy.addSearch("REPL_HB");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/1484");
     cy.get("[data-highlighted='true']").should("contain.text", "REPL_HB");
   });
 
   it("should be able to specify a range of lines to search", () => {
-    cy.dataCy("searchbar-input").type("REPL_HB");
-
-    cy.toggleDetailsPanel(true);
-    cy.dataCy("range-upper-bound").should("be.visible");
-    cy.dataCy("range-upper-bound").type("25");
-    cy.toggleDetailsPanel(false);
+    cy.addSearch("REPL_HB");
+    cy.editBounds({ upper: "25" });
     cy.dataCy("search-count").should("contain.text", "1/7");
-    cy.toggleDetailsPanel(true);
-    cy.dataCy("range-lower-bound").should("be.visible");
-    cy.dataCy("range-lower-bound").type("25");
-    cy.toggleDetailsPanel(false);
+    cy.editBounds({ lower: "25" });
     cy.dataCy("search-count").should("contain.text", "1/1");
-    cy.toggleDetailsPanel(true);
-    cy.dataCy("range-lower-bound").clear();
-    cy.dataCy("range-upper-bound").clear();
-    cy.toggleDetailsPanel(false);
+    cy.clearBounds();
     cy.dataCy("search-count").should("contain.text", "1/1484");
   });
+
   it("should be able to toggle case sensitivity", () => {
-    cy.dataCy("searchbar-input").type("Mongos0");
+    cy.addSearch("Mongos0");
     cy.dataCy("search-count").should("contain.text", "1/1");
-    cy.toggleDetailsPanel(true);
-    cy.dataCy("case-sensitive-toggle").should("be.visible");
-    cy.dataCy("case-sensitive-toggle").should(
-      "have.attr",
-      "aria-checked",
-      "false"
-    );
-    cy.dataCy("case-sensitive-toggle").click({ force: true });
-    cy.dataCy("case-sensitive-toggle").should(
-      "have.attr",
-      "aria-checked",
-      "true"
-    );
-    cy.toggleDetailsPanel(false);
+    cy.clickToggle("case-sensitive-toggle", true);
     cy.dataCy("search-count").should("contain.text", "No Matches");
-    cy.toggleDetailsPanel(true);
-    cy.dataCy("case-sensitive-toggle").click({ force: true });
-    cy.dataCy("case-sensitive-toggle").should(
-      "have.attr",
-      "aria-checked",
-      "false"
-    );
-    cy.toggleDetailsPanel(false);
+    cy.clickToggle("case-sensitive-toggle", false);
     cy.dataCy("search-count").should("contain.text", "1/1");
   });
 
   it("should be able to paginate through search results", () => {
-    cy.dataCy("searchbar-input").type("conn49");
+    cy.addSearch("conn49");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/8");
     // Click the button 8 times
@@ -95,20 +64,11 @@ describe("Searching", () => {
   });
 
   it("should be able to search on filtered content", () => {
-    cy.dataCy("searchbar-input").type("conn49");
-    cy.dataCy("search-count").should("be.visible");
-    cy.dataCy("search-count").should("contain.text", "1/8");
-    cy.dataCy("searchbar-input").clear();
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("filter-option").click();
-    cy.dataCy("searchbar-input").type("conn49");
-    cy.dataCy("searchbar-input").type("{enter}");
+    cy.addFilter("conn49");
     cy.get("[data-cy^='collapsed-row-']").should("exist");
     cy.get("[data-cy^='collapsed-row-']").should("have.length", 7);
-    cy.dataCy("searchbar-select").click();
-    cy.dataCy("search-option").click();
-    cy.dataCy("searchbar-input").clear();
-    cy.dataCy("searchbar-input").type("NETWORK");
+
+    cy.addSearch("NETWORK");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/7");
   });

--- a/cypress/integration/resmokeLogs/resmoke_searching.ts
+++ b/cypress/integration/resmokeLogs/resmoke_searching.ts
@@ -2,10 +2,10 @@ describe("Searching", () => {
   const logLink =
     "/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab";
 
-  before(() => {
+  beforeEach(() => {
     cy.login();
+    cy.setCookie("has-opened-drawer", "true");
     cy.visit(logLink);
-    cy.toggleDrawer();
     cy.dataCy("searchbar-select").click();
     cy.dataCy("search-option").click();
   });
@@ -23,7 +23,6 @@ describe("Searching", () => {
   });
 
   it("searching for a term should snap the matching line to the top of the window", () => {
-    cy.dataCy("searchbar-input").clear();
     cy.dataCy("searchbar-input").type("REPL_HB");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/1484");
@@ -31,6 +30,8 @@ describe("Searching", () => {
   });
 
   it("should be able to specify a range of lines to search", () => {
+    cy.dataCy("searchbar-input").type("REPL_HB");
+
     cy.toggleDetailsPanel(true);
     cy.dataCy("range-upper-bound").should("be.visible");
     cy.dataCy("range-upper-bound").type("25");
@@ -48,7 +49,6 @@ describe("Searching", () => {
     cy.dataCy("search-count").should("contain.text", "1/1484");
   });
   it("should be able to toggle case sensitivity", () => {
-    cy.dataCy("searchbar-input").clear();
     cy.dataCy("searchbar-input").type("Mongos0");
     cy.dataCy("search-count").should("contain.text", "1/1");
     cy.toggleDetailsPanel(true);
@@ -78,7 +78,6 @@ describe("Searching", () => {
   });
 
   it("should be able to paginate through search results", () => {
-    cy.dataCy("searchbar-input").clear();
     cy.dataCy("searchbar-input").type("conn49");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/8");
@@ -96,7 +95,6 @@ describe("Searching", () => {
   });
 
   it("should be able to search on filtered content", () => {
-    cy.dataCy("searchbar-input").clear();
     cy.dataCy("searchbar-input").type("conn49");
     cy.dataCy("search-count").should("be.visible");
     cy.dataCy("search-count").should("contain.text", "1/8");

--- a/cypress/integration/uploadedLogs/upload.ts
+++ b/cypress/integration/uploadedLogs/upload.ts
@@ -3,10 +3,10 @@ describe("Upload page", () => {
     beforeEach(() => {
       cy.login();
       cy.visit("/upload");
-      cy.dataCy("upload-zone").should("be.visible");
     });
 
     it("should be able to drag and drop a file", () => {
+      cy.dataCy("upload-zone").should("be.visible");
       cy.dataCy("upload-zone").selectFile("sample_logs/resmoke.log", {
         force: true,
         action: "drag-drop",
@@ -40,10 +40,10 @@ describe("Upload page", () => {
       cy.login();
       cy.setCookie("has-opened-drawer", "true");
       cy.visit(logLink);
-      cy.dataCy("log-window").should("be.visible");
     });
 
     it("trying to navigate away to the upload page should prompt the user", () => {
+      cy.dataCy("log-window").should("be.visible");
       cy.dataCy("upload-link").click();
       cy.dataCy("confirmation-modal").should("be.visible");
       cy.contains("button", "Confirm").click();

--- a/cypress/integration/uploadedLogs/upload.ts
+++ b/cypress/integration/uploadedLogs/upload.ts
@@ -1,32 +1,52 @@
-describe("log uploading", () => {
-  it("Trying to upload a log prompts the user to select a log type", () => {
-    cy.visit("/upload");
-    cy.dataCy("upload-zone").should("be.visible");
-    cy.get("input[type=file]").selectFile("sample_logs/resmoke.log", {
-      force: true,
+describe("Upload page", () => {
+  describe("uploading logs", () => {
+    beforeEach(() => {
+      cy.login();
+      cy.visit("/upload");
     });
-    cy.dataCy("parse-log-select").should("be.visible");
-  });
-  it("Selecting a logtype should render the log with the appropriate parser", () => {
-    cy.dataCy("parse-log-select").click();
-    cy.contains("Resmoke").click();
-    cy.dataCy("process-log-button").click();
-    cy.dataCy("log-window").should("be.visible");
-    cy.dataCy("resmoke-row").should("be.visible");
-  });
-  it("trying to navigate away to the upload page should prompt the user", () => {
-    cy.dataCy("upload-link").click();
-    cy.dataCy("confirmation-modal").should("be.visible");
-  });
-  it("navigating away clears the logs and returns the user to the upload prompt", () => {
-    cy.contains("Confirm").click();
-    cy.dataCy("upload-zone").should("be.visible");
-  });
-  it("should be able to drag and drop a file", () => {
-    cy.dataCy("upload-zone").selectFile("sample_logs/resmoke.log", {
-      force: true,
-      action: "drag-drop",
+
+    it("should be able to drag and drop a file", () => {
+      cy.dataCy("upload-zone").selectFile("sample_logs/resmoke.log", {
+        force: true,
+        action: "drag-drop",
+      });
+      cy.dataCy("parse-log-select").should("be.visible");
     });
-    cy.dataCy("parse-log-select").should("be.visible");
+    it("should be able to select a file", () => {
+      cy.dataCy("upload-zone").should("be.visible");
+      cy.get("input[type=file]").selectFile("sample_logs/resmoke.log", {
+        force: true,
+      });
+      cy.dataCy("parse-log-select").should("be.visible");
+    });
+    it("selecting a log type should render the log with the appropriate parser", () => {
+      cy.dataCy("upload-zone").should("be.visible");
+      cy.get("input[type=file]").selectFile("sample_logs/resmoke.log", {
+        force: true,
+      });
+      cy.dataCy("parse-log-select").should("be.visible");
+      cy.dataCy("parse-log-select").click();
+      cy.contains("Resmoke").click();
+      cy.dataCy("process-log-button").click();
+      cy.dataCy("log-window").should("be.visible");
+      cy.dataCy("resmoke-row").should("be.visible");
+    });
+  });
+
+  describe("navigating away", () => {
+    const logLink =
+      "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task";
+
+    beforeEach(() => {
+      cy.login();
+      cy.visit(logLink);
+    });
+
+    it("trying to navigate away to the upload page should prompt the user", () => {
+      cy.dataCy("upload-link").click();
+      cy.dataCy("confirmation-modal").should("be.visible");
+      cy.contains("button", "Confirm").click();
+      cy.dataCy("upload-zone").should("be.visible");
+    });
   });
 });

--- a/cypress/integration/uploadedLogs/upload.ts
+++ b/cypress/integration/uploadedLogs/upload.ts
@@ -3,6 +3,7 @@ describe("Upload page", () => {
     beforeEach(() => {
       cy.login();
       cy.visit("/upload");
+      cy.dataCy("upload-zone").should("be.visible");
     });
 
     it("should be able to drag and drop a file", () => {
@@ -13,14 +14,12 @@ describe("Upload page", () => {
       cy.dataCy("parse-log-select").should("be.visible");
     });
     it("should be able to select a file", () => {
-      cy.dataCy("upload-zone").should("be.visible");
       cy.get("input[type=file]").selectFile("sample_logs/resmoke.log", {
         force: true,
       });
       cy.dataCy("parse-log-select").should("be.visible");
     });
     it("selecting a log type should render the log with the appropriate parser", () => {
-      cy.dataCy("upload-zone").should("be.visible");
       cy.get("input[type=file]").selectFile("sample_logs/resmoke.log", {
         force: true,
       });
@@ -39,7 +38,9 @@ describe("Upload page", () => {
 
     beforeEach(() => {
       cy.login();
+      cy.setCookie("has-opened-drawer", "true");
       cy.visit(logLink);
+      cy.dataCy("log-window").should("be.visible");
     });
 
     it("trying to navigate away to the upload page should prompt the user", () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -12,6 +12,18 @@ Cypress.Commands.add("addFilter", (filter: string) => {
   cy.dataCy("searchbar-input").type(`${filter}{enter}`);
 });
 
+Cypress.Commands.add("addHighlight", (highlight: string) => {
+  cy.dataCy("searchbar-select").click();
+  cy.dataCy("highlight-option").click();
+  cy.dataCy("searchbar-input").type(`${highlight}{enter}`);
+});
+
+Cypress.Commands.add("addSearch", (search: string) => {
+  cy.dataCy("searchbar-select").click();
+  cy.dataCy("search-option").click();
+  cy.dataCy("searchbar-input").type(`${search}{enter}`);
+});
+
 Cypress.Commands.add("clearBounds", () => {
   cy.dataCy("details-button").click();
   cy.get(`[data-cy="details-menu"]`).should("be.visible");

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -18,11 +18,18 @@ Cypress.Commands.add("addHighlight", (highlight: string) => {
   cy.dataCy("searchbar-input").type(`${highlight}{enter}`);
 });
 
-Cypress.Commands.add("addSearch", (search: string) => {
-  cy.dataCy("searchbar-select").click();
-  cy.dataCy("search-option").click();
-  cy.dataCy("searchbar-input").type(`${search}{enter}`);
-});
+Cypress.Commands.add(
+  "addSearch",
+  (search: string, shouldSubmit: boolean = false) => {
+    cy.dataCy("searchbar-select").click();
+    cy.dataCy("search-option").click();
+    if (shouldSubmit) {
+      cy.dataCy("searchbar-input").type(`${search}{enter}`);
+    } else {
+      cy.dataCy("searchbar-input").type(`${search}`);
+    }
+  }
+);
 
 Cypress.Commands.add("clearBounds", () => {
   cy.dataCy("details-button").click();

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -17,7 +17,7 @@ declare global {
        * Custom command to add a search.
        * @example cy.addSearch('mySearch')
        */
-      addSearch(search: string): void;
+      addSearch(search: string, shouldSubmit?: boolean): void;
       /**
        * Custom command to click one of the toggles in the Details Menu panel.
        * @example cy.clickToggle('wrap-toggle', true)
@@ -68,7 +68,7 @@ declare global {
       toggleDrawer(): void;
       /**
        * Custom command to open and close the Details Panel.
-       * @example cy.toggleDetailsPanel(open: boolean)
+       * @example cy.toggleDetailsPanel(true)
        */
       toggleDetailsPanel(open: boolean): void;
       /**

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -9,6 +9,16 @@ declare global {
        */
       addFilter(filter: string): void;
       /**
+       * Custom command to add a highlight.
+       * @example cy.addHighlight('myHighlight')
+       */
+      addHighlight(highlight: string): void;
+      /**
+       * Custom command to add a search.
+       * @example cy.addSearch('mySearch')
+       */
+      addSearch(search: string): void;
+      /**
        * Custom command to click one of the toggles in the Details Menu panel.
        * @example cy.clickToggle('wrap-toggle', true)
        */

--- a/src/components/LogRow/AnsiiRow/__snapshots__/AnsiiRow.stories.storyshot
+++ b/src/components/LogRow/AnsiiRow/__snapshots__/AnsiiRow.stories.storyshot
@@ -41,6 +41,7 @@ exports[`storyshots Storyshots Components/LogRow/AnsiiRow Multi Lines 1`] = `
 exports[`storyshots Storyshots Components/LogRow/AnsiiRow Single Line 1`] = `
 <div
   className="css-8iuxnu"
+  data-bookmarked={false}
   data-cy="log-row-0"
   data-highlighted={false}
   data-selected={false}

--- a/src/components/LogRow/BaseRow/index.tsx
+++ b/src/components/LogRow/BaseRow/index.tsx
@@ -99,6 +99,7 @@ const BaseRow = forwardRef<any, BaseRowProps>((props, ref) => {
       ref={ref}
       {...rest}
       bookmarked={bookmarked}
+      data-bookmarked={bookmarked}
       data-cy={`log-row-${lineNumber}`}
       data-highlighted={highlighted}
       data-selected={selected}

--- a/src/components/LogRow/ResmokeRow/__snapshots__/ResmokeRow.stories.storyshot
+++ b/src/components/LogRow/ResmokeRow/__snapshots__/ResmokeRow.stories.storyshot
@@ -79,6 +79,7 @@ exports[`storyshots Storyshots Components/LogRow/ResmokeRow Resmoke Highlighting
 exports[`storyshots Storyshots Components/LogRow/ResmokeRow Single Line 1`] = `
 <div
   className="css-8iuxnu"
+  data-bookmarked={false}
   data-cy="log-row-0"
   data-highlighted={false}
   data-selected={false}


### PR DESCRIPTION
EVG-18681

### Description 
This PR enables Cypress test isolation, and modifies the tests so that they pass under this new setting.

I also used a smaller log file for the `resmoke_filtering.ts` file because the current one being used was taking 4 minutes in CI.

#### Notes
- Running the tests takes longer now (4 minutes as opposed to 3 minutes, according to the Cypress dashboard).
- It's possible to run Cypress tests independently now i.e. you don't need to pre-run tests before you run the test of interest.

### Screenshots
- No visible changes

### Testing 
- Modified various tests in `cypress/integration` folder
- Used a smaller log file for `resmoke_filtering.ts`
