### PR TITLE
EVG-18440: Add legacy links on Parsley

### DIFF
--- a/cypress/integration/externalLinks.ts
+++ b/cypress/integration/externalLinks.ts
@@ -15,6 +15,15 @@ describe("External Links", () => {
         "http://localhost:3000/job-logs/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0"
       );
     });
+    it("should render a link to the Lobster logs", () => {
+      cy.dataCy("lobster-button").should("be.visible");
+      cy.dataCy("lobster-button")
+        .should("have.attr", "href")
+        .and(
+          "contains",
+          "/lobster/evergreen/task/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task"
+        );
+    });
     it("should render links to the log files", () => {
       cy.dataCy("raw-log-button").should("be.visible");
       cy.dataCy("raw-log-button").should("not.be.disabled");
@@ -48,6 +57,15 @@ describe("External Links", () => {
         "http://localhost:3000/job-logs/spruce_ubuntu1604_check_codegen_d54e2c6ede60e004c48d3c4d996c59579c7bbd1f_22_03_02_15_41_35/0"
       );
     });
+    it("should render a link to the Lobster logs", () => {
+      cy.dataCy("lobster-button").should("be.visible");
+      cy.dataCy("lobster-button")
+        .should("have.attr", "href")
+        .and(
+          "contains",
+          "/lobster/evergreen/test/spruce_ubuntu1604_check_codegen_d54e2c6ede60e004c48d3c4d996c59579c7bbd1f_22_03_02_15_41_35/0/JustAFakeTestInALonelyWorld"
+        );
+    });
     it("should render links to the log files", () => {
       cy.dataCy("raw-log-button").should("be.visible");
       cy.dataCy("raw-log-button").should("not.be.disabled");
@@ -75,6 +93,23 @@ describe("External Links", () => {
       );
       cy.toggleDetailsPanel(true);
     });
+    it("should render a link to the job logs page", () => {
+      cy.dataCy("job-logs-button").should("be.visible");
+      cy.dataCy("job-logs-button").should(
+        "have.attr",
+        "href",
+        `http://localhost:8080/build/7e208050e166b1a9025c817b67eee48d`
+      );
+    });
+    it("should render a link to the Lobster logs", () => {
+      cy.dataCy("lobster-button").should("be.visible");
+      cy.dataCy("lobster-button")
+        .should("have.attr", "href")
+        .and(
+          "contains",
+          "/lobster/build/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab"
+        );
+    });
     it("should render links to the log files", () => {
       cy.dataCy("raw-log-button").should("be.visible");
       cy.dataCy("raw-log-button").should("not.be.disabled");
@@ -91,14 +126,7 @@ describe("External Links", () => {
         "http://localhost:8080/build/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab?html=true"
       );
     });
-    it("should render a link to the job logs page", () => {
-      cy.dataCy("job-logs-button").should("be.visible");
-      cy.dataCy("job-logs-button").should(
-        "have.attr",
-        "href",
-        `http://localhost:8080/build/7e208050e166b1a9025c817b67eee48d`
-      );
-    });
+
     it("should render a link to the Evergreen task page", () => {
       cy.contains("Task Page").should("be.visible");
       cy.contains("Task Page").should(

--- a/src/analytics/preferences/usePreferencesAnalytics.ts
+++ b/src/analytics/preferences/usePreferencesAnalytics.ts
@@ -10,6 +10,7 @@ type Action =
   | { name: "Opened Job Logs" }
   | { name: "Opened Raw Logs" }
   | { name: "Opened HTML Logs" }
+  | { name: "Opened Lobster Logs" }
   | { name: "Clicked Copy To Jira" }
   | { name: "Toggled Wrap"; on: boolean }
   | { name: "Toggled Case Sensitivity"; on: boolean }

--- a/src/components/DetailsMenu/ButtonRow/index.tsx
+++ b/src/components/DetailsMenu/ButtonRow/index.tsx
@@ -16,7 +16,7 @@ const ButtonRow: React.FC = () => {
   const [bookmarks] = useQueryParam<number[]>(QueryParams.Bookmarks, []);
   const { getLine, logMetadata } = useLogContext();
   const { sendEvent } = usePreferencesAnalytics();
-  const { htmlLogURL, rawLogURL, jobLogsURL } = logMetadata || {};
+  const { htmlLogURL, rawLogURL, jobLogsURL, lobsterURL } = logMetadata || {};
   const tooltipText = bookmarks.length
     ? "Copy Bookmarked Lines In Jira Format"
     : "No bookmarks to copy.";
@@ -107,6 +107,26 @@ const ButtonRow: React.FC = () => {
         }
       >
         Open log in standard HTML format in a new tab
+      </Tooltip>
+      <Tooltip
+        align="top"
+        justify="middle"
+        trigger={
+          <div data-cy="lobster-button-wrapper">
+            <Button
+              data-cy="lobster-button"
+              disabled={!lobsterURL}
+              href={lobsterURL}
+              leftGlyph={<Icon glyph="Export" />}
+              onClick={() => sendEvent({ name: "Opened Lobster Logs" })}
+              target="_blank"
+            >
+              Lobster
+            </Button>
+          </div>
+        }
+      >
+        View the log using the legacy logviewer in a new tab
       </Tooltip>
     </DetailRow>
   );

--- a/src/constants/logURLTemplates.ts
+++ b/src/constants/logURLTemplates.ts
@@ -1,5 +1,50 @@
-import { evergreenURL, logkeeperURL } from "utils/environmentVariables";
+import {
+  evergreenURL,
+  lobsterURL,
+  logkeeperURL,
+} from "utils/environmentVariables";
 import { stringifyQuery } from "utils/query-string";
+
+/**
+ * @param taskID - the task ID
+ * @param execution - the execution number of the task
+ * @param origin - the origin of the log
+ * @returns a Lobster URL of the format `/evergreen/task/${taskID}/${execution}/${origin}`
+ */
+const getLobsterTaskURL = (
+  taskID: string,
+  execution: string | number,
+  origin: string
+) => `${lobsterURL}/evergreen/task/${taskID}/${execution}/${origin}`;
+
+/**
+ * @param taskID - the task ID
+ * @param execution - the execution number of the task
+ * @param testID - the test ID
+ * @param groupID - the group ID (optional)
+ * @returns a Lobster URL of the format `/evergreen/test/${taskID}/${execution}/${testID}/${groupID}`
+ */
+const getLobsterTestURL = (
+  taskID: string,
+  execution: string | number,
+  testID: string,
+  groupId?: string
+) =>
+  `${lobsterURL}/evergreen/test/${taskID}/${execution}/${testID}${
+    groupId ? `/${groupId}` : ""
+  }`;
+
+/**
+ * @param buildID - the build ID of the resmoke job
+ * @param testID - the test ID of the resmoke log
+ * @returns a Lobster URL of the format `/build/${buildID}/test/${testID}`
+ */
+const getLobsterResmokeURL = (buildID: string, testID?: string) => {
+  if (testID) {
+    return `${lobsterURL}/build/${buildID}/test/${testID}`;
+  }
+  return `${lobsterURL}/build/${buildID}/all`;
+};
 
 /**
  *
@@ -7,17 +52,19 @@ import { stringifyQuery } from "utils/query-string";
  * @param execution - the execution number of the task
  * @param testID - the test ID of the test
  * @param options.text - returns the raw test log
- * @returns /test_log/${taskID}/${execution}?test_name=${testID}&text=true
+ * @param options.groupID - the group ID
+ * @returns /test_log/${taskID}/${execution}?test_name=${testID}&group_id=${groupID}text=true
  */
 const getEvergreenTestLogURL = (
   taskID: string,
   execution: string | number,
   testID: string,
-  options: { text?: boolean }
+  options: { text?: boolean; groupID?: string }
 ) => {
-  const { text } = options;
+  const { text, groupID } = options;
   const params = {
     test_name: testID,
+    group_id: groupID,
     text,
   };
   return `${evergreenURL}/test_log/${taskID}/${execution}?${stringifyQuery(
@@ -82,4 +129,11 @@ const getEvergreenTaskLogURL = (
   )}`;
 };
 
-export { getEvergreenTestLogURL, getResmokeLogURL, getEvergreenTaskLogURL };
+export {
+  getLobsterTaskURL,
+  getLobsterTestURL,
+  getLobsterResmokeURL,
+  getEvergreenTaskLogURL,
+  getEvergreenTestLogURL,
+  getResmokeLogURL,
+};

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -7,11 +7,12 @@ const paths = {
 };
 
 enum slugs {
-  taskID = "task_id",
+  taskID = "taskId",
   execution = "execution",
   origin = "origin",
-  testID = "test_id",
-  buildID = "build_id",
+  testID = "testId",
+  buildID = "buildId",
+  groupID = "groupId",
 }
 
 const routes = {

--- a/src/context/LogContext/types.ts
+++ b/src/context/LogContext/types.ts
@@ -19,6 +19,7 @@ interface LogMetadata {
   htmlLogURL?: string;
   rawLogURL?: string;
   jobLogsURL?: string;
+  lobsterURL?: string;
 }
 
 interface Preferences {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,6 +31,12 @@ const Content: React.FC = () => {
         <Route
           element={<LogView logType={LogTypes.EVERGREEN_TEST_LOGS} />}
           path={routes.testLogs}
+        >
+          <Route element={null} path=":groupId" />
+        </Route>
+        <Route
+          element={<LogView logType={LogTypes.EVERGREEN_TEST_LOGS} />}
+          path={routes.testLogs}
         />
         <Route
           element={<LogView logType={LogTypes.RESMOKE_LOGS} />}

--- a/src/utils/environmentVariables/index.ts
+++ b/src/utils/environmentVariables/index.ts
@@ -1,13 +1,16 @@
-const releaseStage = process.env.REACT_APP_RELEASE_STAGE;
-const evergreenURL = process.env.REACT_APP_EVERGREEN_URL;
-const logkeeperURL = process.env.REACT_APP_LOGKEEPER_URL;
-const bugsnagAPIKey = process.env.REACT_APP_BUGSNAG_API_KEY;
 const appVersion = process.env.REACT_APP_VERSION;
-const isProductionBuild = process.env.NODE_ENV === "production";
+const releaseStage = process.env.REACT_APP_RELEASE_STAGE;
+
+const evergreenURL = process.env.REACT_APP_EVERGREEN_URL;
+const lobsterURL = process.env.REACT_APP_LOBSTER_URL;
+const logkeeperURL = process.env.REACT_APP_LOGKEEPER_URL;
 const spruceURL = process.env.REACT_APP_SPRUCE_URL;
+
+const bugsnagAPIKey = process.env.REACT_APP_BUGSNAG_API_KEY;
 
 const isLocal = releaseStage === "local";
 const isProduction = releaseStage === "production";
+const isProductionBuild = process.env.NODE_ENV === "production";
 const isStaging = releaseStage === "staging";
 
 export {
@@ -18,6 +21,7 @@ export {
   isProduction,
   isProductionBuild,
   isStaging,
+  lobsterURL,
   logkeeperURL,
   releaseStage,
   spruceURL,


### PR DESCRIPTION
EVG-18440

### Description 
This PR adds a link to Lobster under the details menu. You can compare the links with the routes defined in the Lobster repo ([link](https://github.com/evergreen-ci/lobster/blob/e2d21d1fa0853e83c902a570ea833621337c3209/src/components/App/index.js#L39-L64)). To test this PR you will need an updated `.env-cmdrc.json` file which I will distribute in the UI channel.

#### Notes
- I noticed we were missing the optional `groupId` parameter for test logs so I added it in for the raw, HTML, and Lobster log links. You can compare some of these changes with the Evergreen code here ([link](https://github.com/evergreen-ci/evergreen/blob/main/model/task/task.go#L447)).
- Modified test log route to accommodate for the optional `groupId` parameter.

### Screenshots
<img width="758" alt="Screen Shot 2023-01-17 at 3 25 12 PM" src="https://user-images.githubusercontent.com/47064971/213005290-1a5e4c94-62ae-4067-b4c6-cd78ce0d1ab6.png">


### Testing 
- Added tests in `externalLinks.ts` (Cypress)
- Manually on beta
