### PR TITLE
EVG-18680: Replace selectedLine with shareLine param

### DIFF
--- a/cypress/integration/ansiiLogs/ansii_filtering.ts
+++ b/cypress/integration/ansiiLogs/ansii_filtering.ts
@@ -11,13 +11,10 @@ describe("Filtering", () => {
         cy.get(".ReactVirtualized__Grid").should("be.visible");
       });
 
-      it("should not collapse bookmarks and selected line", () => {
+      it("should not collapse bookmarks and share line", () => {
         cy.dataCy("log-link-5").click();
         cy.dataCy("log-row-6").dblclick();
-        cy.location("search").should(
-          "equal",
-          "?bookmarks=0,6,297&selectedLine=5"
-        );
+        cy.location("search").should("equal", "?bookmarks=0,6,297&shareLine=5");
         cy.addFilter("doesNotMatchAnything");
         cy.get("[data-cy^='log-row-']").each(($el) => {
           cy.wrap($el)

--- a/cypress/integration/ansiiLogs/ansii_logView.ts
+++ b/cypress/integration/ansiiLogs/ansii_logView.ts
@@ -70,7 +70,7 @@ describe("Bookmarking and selecting lines", () => {
 
   it("should be able to set and unset the share line", () => {
     cy.dataCy("log-link-5").click();
-    cy.location("search").should("equal", "?bookmarks=0,297&selectedLine=5");
+    cy.location("search").should("equal", "?bookmarks=0,297&shareLine=5");
     cy.dataCy("bookmark-list").should("contain", "0");
     cy.dataCy("bookmark-list").should("contain", "5");
     cy.dataCy("bookmark-list").should("contain", "297");
@@ -140,8 +140,8 @@ describe("Jump to line", () => {
     cy.dataCy("log-row-56").should("be.visible");
   });
 
-  it("visiting a log with a selected line should jump to that line on page load", () => {
-    cy.visit(`${logLink}?bookmarks=0,297&selectedLine=200`);
+  it("visiting a log with a share line should jump to that line on page load", () => {
+    cy.visit(`${logLink}?bookmarks=0,297&shareLine=200`);
     cy.dataCy("log-row-200").should("be.visible");
   });
 });

--- a/cypress/integration/resmokeLogs/resmoke_filtering.ts
+++ b/cypress/integration/resmokeLogs/resmoke_filtering.ts
@@ -11,13 +11,10 @@ describe("Filtering", () => {
         cy.get(".ReactVirtualized__Grid").should("be.visible");
       });
 
-      it("should not collapse bookmarks and selected line", () => {
+      it("should not collapse bookmarks and share line", () => {
         cy.dataCy("log-link-5").click();
         cy.dataCy("log-row-6").dblclick();
-        cy.location("search").should(
-          "equal",
-          "?bookmarks=0,6,130&selectedLine=5"
-        );
+        cy.location("search").should("equal", "?bookmarks=0,6,130&shareLine=5");
         cy.addFilter("doesNotMatchAnything");
         cy.get("[data-cy^='log-row-']").each(($el) => {
           cy.wrap($el)

--- a/cypress/integration/resmokeLogs/resmoke_logView.ts
+++ b/cypress/integration/resmokeLogs/resmoke_logView.ts
@@ -112,7 +112,7 @@ describe("Bookmarking and selecting lines", () => {
 
   it("should be able to set and unset the share line", () => {
     cy.dataCy("log-link-5").click();
-    cy.location("search").should("equal", "?bookmarks=0,11079&selectedLine=5");
+    cy.location("search").should("equal", "?bookmarks=0,11079&shareLine=5");
     cy.dataCy("bookmark-list").should("contain", "0");
     cy.dataCy("bookmark-list").should("contain", "5");
     cy.dataCy("bookmark-list").should("contain", "11079");
@@ -184,8 +184,8 @@ describe("Jump to line", () => {
     cy.dataCy("log-row-30").should("be.visible");
   });
 
-  it("visiting a log with a selected line should jump to that line on page load", () => {
-    cy.visit(`${logLink}?bookmarks=0,11079&selectedLine=200`);
+  it("visiting a log with a share line should jump to that line on page load", () => {
+    cy.visit(`${logLink}?bookmarks=0,11079&shareLine=200`);
     cy.dataCy("log-row-200").should("be.visible");
   });
 });

--- a/cypress/integration/routes.ts
+++ b/cypress/integration/routes.ts
@@ -39,15 +39,26 @@ describe("Parsley Routes", () => {
     cy.dataCy("404").should("be.visible");
   });
 
-  // This test can be deleted in EVG-18748.
-  it("should redirect selectedLine to shareLine, preserving all other query params", () => {
-    cy.visit(
-      "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task?bookmarks=0,297&filters=100this%2520is%2520a%2520filter&highlights=this%2520is%2520a%2520highlight&selectedLine=7"
-    );
-    cy.location("search").should("not.contain", "selectedLine");
-    cy.location("search").should(
-      "equal",
-      "?bookmarks=0,297&filters=100this%2520is%2520a%2520filter&highlights=this%2520is%2520a%2520highlight&shareLine=7"
-    );
+  // This test block can be deleted in EVG-18748.
+  describe("redirecting", () => {
+    it("should redirect selectedLine to shareLine, preserving all other query params", () => {
+      cy.visit(
+        "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task?bookmarks=0,297&filters=100this%2520is%2520a%2520filter&highlights=this%2520is%2520a%2520highlight&selectedLine=7"
+      );
+      cy.location("search").should("not.contain", "selectedLine");
+      cy.location("search").should(
+        "equal",
+        "?bookmarks=0,297&filters=100this%2520is%2520a%2520filter&highlights=this%2520is%2520a%2520highlight&shareLine=7"
+      );
+    });
+    it("should correctly jump to line when selectedLine is replaced by shareLine param", () => {
+      cy.visit(
+        "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task?bookmarks=0,297&selectedLine=200"
+      );
+      cy.location("search").should("not.contain", "selectedLine");
+      cy.location("search").should("equal", "?bookmarks=0,297&shareLine=200");
+      cy.dataCy("log-row-200").should("be.visible"); // Should have jumped to line 200.
+      cy.get("[data-shared='true']").should("be.visible");
+    });
   });
 });

--- a/cypress/integration/routes.ts
+++ b/cypress/integration/routes.ts
@@ -38,4 +38,16 @@ describe("Parsley Routes", () => {
     cy.visit("/this/is/not/a/real/page");
     cy.dataCy("404").should("be.visible");
   });
+
+  // This test can be deleted in EVG-18748.
+  it("should redirect selectedLine to shareLine, preserving all other query params", () => {
+    cy.visit(
+      "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task?bookmarks=0,297&filters=100this%2520is%2520a%2520filter&highlights=this%2520is%2520a%2520highlight&selectedLine=7"
+    );
+    cy.location("search").should("not.contain", "selectedLine");
+    cy.location("search").should(
+      "equal",
+      "?bookmarks=0,297&filters=100this%2520is%2520a%2520filter&highlights=this%2520is%2520a%2520highlight&shareLine=7"
+    );
+  });
 });

--- a/src/components/BookmarksBar/BookmarksBar.test.tsx
+++ b/src/components/BookmarksBar/BookmarksBar.test.tsx
@@ -41,7 +41,7 @@ describe("bookmarks bar", () => {
     });
   });
 
-  it("should properly display sorted bookmarks and selectedLine", () => {
+  it("should properly display sorted bookmarks and shareLine", () => {
     renderWithRouterMatch(
       <BookmarksBar
         lineCount={11}
@@ -49,7 +49,7 @@ describe("bookmarks bar", () => {
         scrollToLine={jest.fn()}
       />,
       {
-        route: "?bookmarks=1,7&selectedLine=5",
+        route: "?bookmarks=1,7&shareLine=5",
       }
     );
     const { children } = screen.getByDataCy("bookmark-list");
@@ -62,7 +62,7 @@ describe("bookmarks bar", () => {
     expect((children.item(2) as Element).textContent).toContain("7");
   });
 
-  it("should be able to clear all bookmarks without removing selected line", async () => {
+  it("should be able to clear all bookmarks without removing share line", async () => {
     const { history } = renderWithRouterMatch(
       <BookmarksBar
         lineCount={11}
@@ -70,11 +70,11 @@ describe("bookmarks bar", () => {
         scrollToLine={jest.fn()}
       />,
       {
-        route: "?bookmarks=1,3&selectedLine=5",
+        route: "?bookmarks=1,3&shareLine=5",
       }
     );
     await userEvent.click(screen.getByDataCy("clear-bookmarks"));
-    expect(history.location.search).toBe("?selectedLine=5");
+    expect(history.location.search).toBe("?shareLine=5");
   });
 
   it("should call scrollToLine when clicking on a log line (with no collapsed lines)", async () => {

--- a/src/components/BookmarksBar/index.tsx
+++ b/src/components/BookmarksBar/index.tsx
@@ -7,7 +7,7 @@ import { useLogWindowAnalytics } from "analytics";
 import Icon from "components/Icon";
 import { QueryParams } from "constants/queryParams";
 import { size } from "constants/tokens";
-import { useQueryParam, useQueryParams } from "hooks/useQueryParam";
+import { useQueryParam } from "hooks/useQueryParam";
 import { findLineIndex } from "utils/findLineIndex";
 
 const { gray, green } = palette;
@@ -24,12 +24,7 @@ const BookmarksBar: React.FC<BookmarksBarProps> = ({
   scrollToLine,
 }) => {
   const { sendEvent } = useLogWindowAnalytics();
-  const [searchParams, setSearchParams] = useQueryParams();
 
-  const [selectedLine] = useQueryParam<number | undefined>(
-    QueryParams.SelectedLine,
-    undefined
-  );
   const [shareLine] = useQueryParam<number | undefined>(
     QueryParams.ShareLine,
     undefined
@@ -38,18 +33,6 @@ const BookmarksBar: React.FC<BookmarksBarProps> = ({
     QueryParams.Bookmarks,
     []
   );
-
-  // If selectedLine is in the URL, replace it with shareLine.
-  // This code can be deleted in EVG-18748.
-  useEffect(() => {
-    if (selectedLine) {
-      setSearchParams({
-        ...searchParams,
-        shareLine: selectedLine,
-        selectedLine: undefined,
-      });
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Set the initial bookmarks on load.
   useEffect(() => {

--- a/src/components/BookmarksBar/index.tsx
+++ b/src/components/BookmarksBar/index.tsx
@@ -7,7 +7,7 @@ import { useLogWindowAnalytics } from "analytics";
 import Icon from "components/Icon";
 import { QueryParams } from "constants/queryParams";
 import { size } from "constants/tokens";
-import { useQueryParam } from "hooks/useQueryParam";
+import { useQueryParam, useQueryParams } from "hooks/useQueryParam";
 import { findLineIndex } from "utils/findLineIndex";
 
 const { gray, green } = palette;
@@ -24,15 +24,32 @@ const BookmarksBar: React.FC<BookmarksBarProps> = ({
   scrollToLine,
 }) => {
   const { sendEvent } = useLogWindowAnalytics();
+  const [searchParams, setSearchParams] = useQueryParams();
 
   const [selectedLine] = useQueryParam<number | undefined>(
     QueryParams.SelectedLine,
+    undefined
+  );
+  const [shareLine] = useQueryParam<number | undefined>(
+    QueryParams.ShareLine,
     undefined
   );
   const [bookmarks, setBookmarks] = useQueryParam<number[]>(
     QueryParams.Bookmarks,
     []
   );
+
+  // If selectedLine is in the URL, replace it with shareLine.
+  // This code can be deleted in EVG-18748.
+  useEffect(() => {
+    if (selectedLine) {
+      setSearchParams({
+        ...searchParams,
+        shareLine: selectedLine,
+        selectedLine: undefined,
+      });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Set the initial bookmarks on load.
   useEffect(() => {
@@ -46,8 +63,8 @@ const BookmarksBar: React.FC<BookmarksBarProps> = ({
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const lineNumbers =
-    selectedLine !== undefined
-      ? Array.from(new Set([...bookmarks, selectedLine])).sort((a, b) => a - b)
+    shareLine !== undefined
+      ? Array.from(new Set([...bookmarks, shareLine])).sort((a, b) => a - b)
       : bookmarks;
 
   // Finds the corresponding index of a line number and scrolls to it.
@@ -87,7 +104,7 @@ const BookmarksBar: React.FC<BookmarksBarProps> = ({
             }}
           >
             <span>{l}</span>
-            {l === selectedLine && <StyledIcon glyph="Link" size="small" />}
+            {l === shareLine && <StyledIcon glyph="Link" size="small" />}
           </LogLineNumber>
         ))}
       </LogLineContainer>

--- a/src/components/LogPane/index.tsx
+++ b/src/components/LogPane/index.tsx
@@ -37,8 +37,8 @@ const LogPane: React.FC<LogPaneProps> = ({
   } = useLogContext();
   const { expandableRows, prettyPrint } = preferences;
 
-  const [selectedLine] = useQueryParam<number | undefined>(
-    QueryParams.SelectedLine,
+  const [shareLine] = useQueryParam<number | undefined>(
+    QueryParams.ShareLine,
     undefined
   );
 
@@ -48,7 +48,7 @@ const LogPane: React.FC<LogPaneProps> = ({
   }, [listRef, cache, wrap, matchingLines, expandableRows, prettyPrint]);
 
   useEffect(() => {
-    const initialScrollIndex = findLineIndex(processedLogLines, selectedLine);
+    const initialScrollIndex = findLineIndex(processedLogLines, shareLine);
     if (initialScrollIndex > -1) {
       leaveBreadcrumb("Scrolled to initialScrollIndex", {
         initialScrollIndex,

--- a/src/components/LogRow/AnsiiRow/AnsiiRow.test.tsx
+++ b/src/components/LogRow/AnsiiRow/AnsiiRow.test.tsx
@@ -65,7 +65,7 @@ describe("ansiiRow", () => {
     );
     expect(screen.getByText(logLines[1])).toBeInTheDocument();
   });
-  it("clicking log line link updates the url and selects it", async () => {
+  it("clicking log line link updates the url and marks it as a share line", async () => {
     const scrollToLine = jest.fn();
     const { history } = renderWithRouterMatch(
       <AnsiiRow
@@ -78,16 +78,16 @@ describe("ansiiRow", () => {
       }
     );
     await user.click(screen.getByDataCy("log-link-0"));
-    expect(history.location.search).toBe("?selectedLine=0");
+    expect(history.location.search).toBe("?shareLine=0");
     expect(scrollToLine).toHaveBeenCalledWith(0);
   });
-  it("clicking on a selected log line link unselects it", async () => {
+  it("clicking on a share line's link icon updates the URL correctly", async () => {
     const { history } = renderWithRouterMatch(
       <AnsiiRow data={data} lineNumber={0} listRowProps={listRowProps} />,
 
       {
         wrapper: wrapper(logLines),
-        route: "?selectedLine=0",
+        route: "?shareLine=0",
       }
     );
     await user.click(screen.getByDataCy("log-link-0"));

--- a/src/components/LogRow/AnsiiRow/__snapshots__/AnsiiRow.stories.storyshot
+++ b/src/components/LogRow/AnsiiRow/__snapshots__/AnsiiRow.stories.storyshot
@@ -44,9 +44,8 @@ exports[`storyshots Storyshots Components/LogRow/AnsiiRow Single Line 1`] = `
   data-bookmarked={false}
   data-cy="log-row-0"
   data-highlighted={false}
-  data-selected={false}
+  data-shared={false}
   onDoubleClick={[Function]}
-  selected={false}
   style={Object {}}
 >
   <svg

--- a/src/components/LogRow/BaseRow/Row.test.tsx
+++ b/src/components/LogRow/BaseRow/Row.test.tsx
@@ -21,15 +21,15 @@ describe("row", () => {
       </Row>
     );
     await userEvent.click(screen.getByDataCy("log-link-54"));
-    expect(history.location.search).toBe("?selectedLine=54");
+    expect(history.location.search).toBe("?shareLine=54");
     expect(scrollToLine).toHaveBeenCalledWith(7);
   });
 
-  it("clicking on a selected log line link unselects it", async () => {
+  it("clicking on a share line's link icon updates the URL correctly", async () => {
     const { history } = renderWithRouterMatch(
       <Row {...rowProps}>{testLog}</Row>,
       {
-        route: "?selectedLine=0",
+        route: "?shareLine=0",
       }
     );
     await userEvent.click(screen.getByDataCy("log-link-0"));
@@ -55,13 +55,13 @@ describe("row", () => {
     expect(history.location.search).toBe("");
   });
 
-  it("a log line can be selected and bookmarked at the same time", async () => {
+  it("a log line can be shared and bookmarked at the same time", async () => {
     const { history } = renderWithRouterMatch(
       <Row {...rowProps}>{testLog}</Row>
     );
     await userEvent.click(screen.getByDataCy("log-link-0"));
     await userEvent.dblClick(screen.getByText(testLog));
-    expect(history.location.search).toBe("?bookmarks=0&selectedLine=0");
+    expect(history.location.search).toBe("?bookmarks=0&shareLine=0");
   });
   describe("search", () => {
     it("a search term highlights the matching text", () => {

--- a/src/components/LogRow/BaseRow/index.tsx
+++ b/src/components/LogRow/BaseRow/index.tsx
@@ -33,7 +33,7 @@ interface BaseRowProps extends ListRowProps {
 
 /**
  * BaseRow is meant to be used as a wrapper for all rows in the log view.
- * It is responsible for handling the highlighting of the selected line
+ * It is responsible for handling the highlighting of the share line and bookmarks.
  */
 const BaseRow = forwardRef<any, BaseRowProps>((props, ref) => {
   const {
@@ -52,11 +52,11 @@ const BaseRow = forwardRef<any, BaseRowProps>((props, ref) => {
     ...rest
   } = props;
 
-  const [selectedLine, setSelectedLine] = useQueryParam<number | undefined>(
-    QueryParams.SelectedLine,
+  const [shareLine, setShareLine] = useQueryParam<number | undefined>(
+    QueryParams.ShareLine,
     undefined
   );
-  const selected = selectedLine === lineNumber;
+  const shared = shareLine === lineNumber;
 
   const [bookmarks, setBookmarks] = useQueryParam<number[]>(
     QueryParams.Bookmarks,
@@ -69,10 +69,10 @@ const BaseRow = forwardRef<any, BaseRowProps>((props, ref) => {
 
   // Clicking a line should select or deselect the line.
   const handleClick = () => {
-    if (selected) {
-      setSelectedLine(undefined);
+    if (shared) {
+      setShareLine(undefined);
     } else {
-      setSelectedLine(lineNumber);
+      setShareLine(lineNumber);
       scrollToLine(index);
     }
   };
@@ -102,14 +102,14 @@ const BaseRow = forwardRef<any, BaseRowProps>((props, ref) => {
       data-bookmarked={bookmarked}
       data-cy={`log-row-${lineNumber}`}
       data-highlighted={highlighted}
-      data-selected={selected}
+      data-shared={shared}
       highlighted={highlighted}
       onDoubleClick={handleDoubleClick}
-      selected={selected}
+      shared={shared}
     >
       <StyledIcon
         data-cy={`log-link-${lineNumber}`}
-        glyph={selected ? "ArrowWithCircle" : "Link"}
+        glyph={shared ? "ArrowWithCircle" : "Link"}
         onClick={handleClick}
         size="small"
       />
@@ -178,7 +178,7 @@ ProcessedBaseRow.displayName = "ProcessedBaseRow";
 BaseRow.displayName = "BaseRow";
 
 const RowContainer = styled.div<{
-  selected: boolean;
+  shared: boolean;
   bookmarked: boolean;
   highlighted: boolean;
 }>`
@@ -190,7 +190,7 @@ const RowContainer = styled.div<{
   font-size: ${fontSize.m};
 
   ${({ color }) => color && `color: ${color};`}
-  ${({ selected }) => selected && `background-color: ${yellow.light3};`}
+  ${({ shared }) => shared && `background-color: ${yellow.light3};`}
   ${({ bookmarked }) => bookmarked && `background-color: ${yellow.light3};`}
   ${({ highlighted }) => highlighted && `background-color: ${red.light3};`}
 

--- a/src/components/LogRow/ResmokeRow/ResmokeRow.test.tsx
+++ b/src/components/LogRow/ResmokeRow/ResmokeRow.test.tsx
@@ -65,7 +65,7 @@ describe("resmokeRow", () => {
     );
     expect(screen.getByText(logLines[1])).toBeInTheDocument();
   });
-  it("clicking log line link updates the url and selects it", async () => {
+  it("clicking log line link updates the url and marks it as a share line", async () => {
     const scrollToLine = jest.fn();
     const { history } = renderWithRouterMatch(
       <ResmokeRow
@@ -78,16 +78,16 @@ describe("resmokeRow", () => {
       }
     );
     await user.click(screen.getByDataCy("log-link-0"));
-    expect(history.location.search).toBe("?selectedLine=0");
+    expect(history.location.search).toBe("?shareLine=0");
     expect(scrollToLine).toHaveBeenCalledWith(0);
   });
-  it("clicking on a selected log line link unselects it", async () => {
+  it("clicking on a share line's link icon updates the URL correctly", async () => {
     const { history } = renderWithRouterMatch(
       <ResmokeRow data={data} lineNumber={0} listRowProps={listRowProps} />,
 
       {
         wrapper: wrapper(logLines),
-        route: "?selectedLine=0",
+        route: "?shareLine=0",
       }
     );
     await user.click(screen.getByDataCy("log-link-0"));

--- a/src/components/LogRow/ResmokeRow/__snapshots__/ResmokeRow.stories.storyshot
+++ b/src/components/LogRow/ResmokeRow/__snapshots__/ResmokeRow.stories.storyshot
@@ -82,9 +82,8 @@ exports[`storyshots Storyshots Components/LogRow/ResmokeRow Single Line 1`] = `
   data-bookmarked={false}
   data-cy="log-row-0"
   data-highlighted={false}
-  data-selected={false}
+  data-shared={false}
   onDoubleClick={[Function]}
-  selected={false}
   style={Object {}}
 >
   <svg

--- a/src/constants/queryParams.ts
+++ b/src/constants/queryParams.ts
@@ -3,7 +3,8 @@ enum QueryParams {
   Highlights = "highlights",
   Bookmarks = "bookmarks",
   Filters = "filters",
-  SelectedLine = "selectedLine",
+  ShareLine = "shareLine",
+  SelectedLine = "selectedLine", // Delete this as part of EVG-18748.
   Wrap = "wrap",
   Expandable = "expandable",
   FilterLogic = "filterLogic",

--- a/src/context/LogContext/index.tsx
+++ b/src/context/LogContext/index.tsx
@@ -82,10 +82,11 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
 }) => {
   const [filters] = useFilterParam();
   const [bookmarks] = useQueryParam<number[]>(QueryParams.Bookmarks, []);
-  const [selectedLine] = useQueryParam<number | undefined>(
-    QueryParams.SelectedLine,
+  const [shareLine] = useQueryParam<number | undefined>(
+    QueryParams.ShareLine,
     undefined
   );
+
   const [upperRange] = useQueryParam<undefined | number>(
     QueryParams.UpperRange,
     undefined
@@ -134,7 +135,7 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
           logLines: state.logs,
           matchingLines,
           bookmarks,
-          selectedLine,
+          shareLine,
           expandedLines: state.expandedLines,
           expandableRows,
         })
@@ -145,7 +146,7 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
       state.logs.length,
       matchingLines,
       stringifiedBookmarks,
-      selectedLine,
+      shareLine,
       stringifiedExpandedLines,
       expandableRows,
     ]

--- a/src/context/LogContext/index.tsx
+++ b/src/context/LogContext/index.tsx
@@ -20,7 +20,7 @@ import {
 import { FilterLogic, LogTypes } from "constants/enums";
 import { QueryParams } from "constants/queryParams";
 import { useFilterParam } from "hooks/useFilterParam";
-import { useQueryParam } from "hooks/useQueryParam";
+import { useQueryParam, useQueryParams } from "hooks/useQueryParam";
 import { ExpandedLines, ProcessedLogLines } from "types/logs";
 import filterLogs from "utils/filterLogs";
 import { getMatchingLines } from "utils/matchingLines";
@@ -80,10 +80,15 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
   children,
   initialLogLines,
 }) => {
+  const [searchParams, setSearchParams] = useQueryParams();
   const [filters] = useFilterParam();
   const [bookmarks] = useQueryParam<number[]>(QueryParams.Bookmarks, []);
   const [shareLine] = useQueryParam<number | undefined>(
     QueryParams.ShareLine,
+    undefined
+  );
+  const [selectedLine] = useQueryParam<number | undefined>(
+    QueryParams.SelectedLine,
     undefined
   );
 
@@ -151,6 +156,18 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
       expandableRows,
     ]
   );
+
+  // If selectedLine is in the URL, replace it with shareLine.
+  // This block of code can be deleted in EVG-18748.
+  useEffect(() => {
+    if (selectedLine) {
+      setSearchParams({
+        ...searchParams,
+        shareLine: selectedLine,
+        selectedLine: undefined,
+      });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const getLine = useCallback(
     (lineNumber: number) => state.logs[lineNumber],

--- a/src/utils/filterLogs/filterLogs.test.ts
+++ b/src/utils/filterLogs/filterLogs.test.ts
@@ -18,7 +18,7 @@ describe("filterLogs", () => {
         logLines,
         matchingLines: undefined,
         bookmarks: [],
-        selectedLine: undefined,
+        shareLine: undefined,
         expandedLines: [],
         expandableRows: true,
       })
@@ -31,7 +31,7 @@ describe("filterLogs", () => {
         logLines,
         matchingLines: new Set([1, 2, 3]),
         bookmarks: [],
-        selectedLine: undefined,
+        shareLine: undefined,
         expandedLines: [],
         expandableRows: false,
       })
@@ -44,7 +44,7 @@ describe("filterLogs", () => {
         logLines,
         matchingLines: new Set([]),
         bookmarks: [],
-        selectedLine: undefined,
+        shareLine: undefined,
         expandedLines: [],
         expandableRows: true,
       })
@@ -58,20 +58,20 @@ describe("filterLogs", () => {
           logLines,
           matchingLines: new Set([1]),
           bookmarks: [7],
-          selectedLine: undefined,
+          shareLine: undefined,
           expandedLines: [],
           expandableRows: true,
         })
       ).toStrictEqual([[0], 1, [2, 3, 4, 5, 6], 7]);
     });
 
-    it("should not collapse selected lines", () => {
+    it("should not collapse the share line", () => {
       expect(
         filterLogs({
           logLines,
           matchingLines: new Set([1]),
           bookmarks: [],
-          selectedLine: 7,
+          shareLine: 7,
           expandedLines: [],
           expandableRows: true,
         })
@@ -84,7 +84,7 @@ describe("filterLogs", () => {
           logLines,
           matchingLines: new Set([1]),
           bookmarks: [],
-          selectedLine: undefined,
+          shareLine: undefined,
           expandedLines: [[4, 6]],
           expandableRows: true,
         })

--- a/src/utils/filterLogs/index.ts
+++ b/src/utils/filterLogs/index.ts
@@ -6,17 +6,17 @@ type FilterLogsParams = {
   logLines: string[];
   matchingLines: Set<number> | undefined;
   bookmarks: number[];
-  selectedLine: number | undefined;
+  shareLine: number | undefined;
   expandedLines: ExpandedLines;
   expandableRows: boolean;
 };
 
 /**
- * `filterLogs` processes log lines according to what filters, bookmarks, selected line, and expanded lines are applied.
+ * `filterLogs` processes log lines according to what filters, bookmarks, share line, and expanded lines are applied.
  * @param {string[]} obj.logLines - list of strings representing the log lines
  * @param {Set<number>} obj.matchingLines - set of numbers representing which lines match the applied filters
  * @param {number[]} obj.bookmarks - list of line numbers representing bookmarks
- * @param {number | undefined} obj.selectedLine - a line number representing a selected line
+ * @param {number | undefined} obj.shareLine - a line number representing a share line
  * @param {ExpandedLines} obj.expandedLines - an array of intervals representing expanded ranges
  * @param {boolean} obj.expandableRows - specifies if expandable rows is enabled
  * @returns an array of numbers that indicates which log lines should be displayed, and which log lines
@@ -26,7 +26,7 @@ const filterLogs = ({
   logLines,
   matchingLines,
   bookmarks,
-  selectedLine,
+  shareLine,
   expandedLines,
   expandableRows,
 }: FilterLogsParams): (number | number[])[] => {
@@ -39,10 +39,10 @@ const filterLogs = ({
   const filteredLines: ProcessedLogLines = [];
 
   logLines.reduce((arr, _logLine, idx) => {
-    // Bookmarks, selected lines, and expanded lines should always remain uncollapsed.
+    // Bookmarks, expanded lines, and the share line should always remain uncollapsed.
     if (
       bookmarks.includes(idx) ||
-      selectedLine === idx ||
+      shareLine === idx ||
       isExpanded(idx, expandedLines)
     ) {
       arr.push(idx);


### PR DESCRIPTION
EVG-18680

### Description 
This PR makes it so that the `selectedLine` param is replaced with the `shareLine` param. `shareLine` is a better name for this query param because it makes it clear what it does.

I opened [EVG-18748](https://jira.mongodb.org/browse/EVG-18748) to delete the code around `selectedLine` at a later date.

### Screenshots
- No visible changes.

### Testing 
- Added test in `routes.ts` (Cypress)

### Note 
This ticket also includes updating the links in Evergreen [here](https://github.com/evergreen-ci/evergreen/blob/main/model/task/task.go#L483-L486). However, this PR will need to be merged and deployed **_before_** that change is made.