### PR TITLE
EVG-18491: Fix laggy loading animation on Chrome

### DIFF
--- a/src/pages/LogView/LoadingPage/index.tsx
+++ b/src/pages/LogView/LoadingPage/index.tsx
@@ -145,9 +145,9 @@ const LoadingPage: React.FC<LoadingPageProps> = ({ logType }) => {
       {isLoading || !error ? (
         <LoadingBarContainer>
           <LogoContainer>
-            <Animation>
+            <AnimationWrapper>
               <Icon glyph="ParsleyLogo" size={40} useStroke />
-            </Animation>
+            </AnimationWrapper>
             <StyledBody>Loading Parsley...</StyledBody>
           </LogoContainer>
           <LoadingBar indeterminate />
@@ -170,14 +170,10 @@ const LoadingBarContainer = styled.div`
 const LogoContainer = styled.div`
   display: flex;
   align-items: flex-end;
+  gap: ${size.s};
 `;
 
-const StyledBody = styled(Body)`
-  font-size: ${fontSize.l};
-`;
-
-const Animation = styled.div`
-  margin-right: ${size.s};
+const AnimationWrapper = styled.div`
   animation: sway 3s infinite ease-in-out;
   transform-origin: bottom;
   @keyframes sway {
@@ -197,6 +193,10 @@ const Animation = styled.div`
       transform: rotateZ(0deg);
     }
   }
+`;
+
+const StyledBody = styled(Body)`
+  font-size: ${fontSize.l};
 `;
 
 const Container = styled.div`

--- a/src/pages/LogView/LoadingPage/index.tsx
+++ b/src/pages/LogView/LoadingPage/index.tsx
@@ -145,7 +145,9 @@ const LoadingPage: React.FC<LoadingPageProps> = ({ logType }) => {
       {isLoading || !error ? (
         <LoadingBarContainer>
           <LogoContainer>
-            <StyledIcon glyph="ParsleyLogo" size={40} useStroke />
+            <Animation>
+              <Icon glyph="ParsleyLogo" size={40} useStroke />
+            </Animation>
             <StyledBody>Loading Parsley...</StyledBody>
           </LogoContainer>
           <LoadingBar indeterminate />
@@ -174,25 +176,25 @@ const StyledBody = styled(Body)`
   font-size: ${fontSize.l};
 `;
 
-const StyledIcon = styled(Icon)`
+const Animation = styled.div`
   margin-right: ${size.s};
-  animation: sway infinite 3s ease-in-out;
+  animation: sway 3s infinite ease-in-out;
   transform-origin: bottom;
   @keyframes sway {
     0% {
-      transform: rotate(0deg);
+      transform: rotateZ(0deg);
     }
     25% {
-      transform: rotate(-5deg);
+      transform: rotateZ(-5deg);
     }
     50% {
-      transform: rotate(5deg);
+      transform: rotateZ(5deg);
     }
     75% {
-      transform: rotate(-5deg);
+      transform: rotateZ(-5deg);
     }
     100% {
-      transform: rotate(0deg);
+      transform: rotateZ(0deg);
     }
   }
 `;


### PR DESCRIPTION
EVG-18491

### Description 
This PR fixes the laggy animation when loading a large log file on Chrome. Initially I (incorrectly) thought we might have to move the log processing off of the main thread, but then I noticed how the animation wouldn't lag at all on Safari but would perform pretty terribly on Chrome.

I think what's happening is that Chrome doesn't handle animating SVGs well (the Parsley icon gets rendered as an SVG.) Wrapping the SVG in a `div` and applying the animation on the `div` got rid of the lag.

### Screenshots
(On Chrome)

https://user-images.githubusercontent.com/47064971/213779971-05a4d467-b197-4667-8694-b67135840129.mov


### Testing 
- Manually looking
