### PR TITLE
EVG-18162: Mock out console in Jest tests

### DIFF
--- a/config/jest/setupTests.ts
+++ b/config/jest/setupTests.ts
@@ -1,3 +1,4 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
 import "@testing-library/jest-dom/extend-expect";
 
 // Avoid printing debug statements when running tests.

--- a/config/jest/setupTests.ts
+++ b/config/jest/setupTests.ts
@@ -1,0 +1,16 @@
+import "@testing-library/jest-dom/extend-expect";
+
+// Avoid printing debug statements when running tests.
+jest.spyOn(console, "debug").mockImplementation();
+
+// Avoid printing error statements when running tests.
+jest.spyOn(console, "error").mockImplementation();
+
+// Avoid printing analytics events when running tests, but print any other console.log statements.
+const consoleLog = console.log;
+console.log = (message: string) => {
+  if (message.startsWith("ANALYTICS EVENT")) {
+    return;
+  }
+  consoleLog(message);
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   preset: "ts-jest",
   resetMocks: true,
   // jest-dom adds custom jest matchers for asserting on DOM nodes.
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  setupFilesAfterEnv: ["<rootDir>/config/jest/setupTests.ts"],
   snapshotSerializers: ["@emotion/jest/serializer"],
   testEnvironment: "jsdom",
   testMatch: ["<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}"],

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,6 @@ module.exports = {
   setupFiles: ["whatwg-fetch"],
   preset: "ts-jest",
   resetMocks: true,
-  // jest-dom adds custom jest matchers for asserting on DOM nodes.
   setupFilesAfterEnv: ["<rootDir>/config/jest/setupTests.ts"],
   snapshotSerializers: ["@emotion/jest/serializer"],
   testEnvironment: "jsdom",

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -28,17 +28,14 @@ class DefaultErrorBoundary extends Component<
   constructor(props: DefaultErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false };
-    console.log("DefaultErrorBoundary");
   }
 
   static getDerivedStateFromError() {
-    console.log("getDerivedStateFromError");
     // Update state so the next render will show the fallback UI.
     return { hasError: true };
   }
 
   componentDidCatch(error: Error, errorInfo: any) {
-    console.log("componentDidCatch");
     console.error({ error, errorInfo });
   }
 

--- a/src/components/NavBar/UploadLink/UploadLink.test.tsx
+++ b/src/components/NavBar/UploadLink/UploadLink.test.tsx
@@ -50,12 +50,14 @@ describe("uploadLink", () => {
 
   it("confirming the modal clears logs and navigates to /upload", async () => {
     const clearLogs = jest.fn();
-    const { history } = render(<UploadLink clearLogs={clearLogs} hasLogs />);
+    const { history } = render(<UploadLink clearLogs={clearLogs} hasLogs />, {
+      route: "/upload",
+      path: "/upload",
+    });
     await user.click(screen.getByText("Upload"));
     await waitFor(() => {
       expect(screen.queryByDataCy("confirmation-modal")).toBeVisible();
     });
-
     const confirmButton = screen.getByRole("button", {
       name: "Confirm",
     });

--- a/src/components/Search/SearchBar/SearchBar.stories.tsx
+++ b/src/components/Search/SearchBar/SearchBar.stories.tsx
@@ -25,6 +25,5 @@ Default.argTypes = {
   validator: {
     control: "func",
     description: "Function to validate input",
-    defaultValue: "() => true",
   },
 };

--- a/src/context/toast/toast.test.tsx
+++ b/src/context/toast/toast.test.tsx
@@ -28,15 +28,10 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 
 describe("toast", () => {
   it("should error when rendered outside of ToastProvider context", () => {
-    // This test intentionally throws an error, so we need to mock the error object to prevent it
-    // from flooding the test runner.
-    const errorObject = console.error;
-    jest.spyOn(console, "error").mockImplementation();
     const { Component } = renderComponentWithHook();
     expect(() => render(<Component />)).toThrow(
       "useToastContext must be used within a ToastProvider"
     );
-    console.error = errorObject;
   });
 
   it("should not display a toast by default", () => {


### PR DESCRIPTION
EVG-18162

### Description 
This PR mocks out some `console` logging to help our Jest tests be less noisy. `console.debug` and `console.error` are ignored completely, while `console.log` only ignores analytics events. This is to help catch stray `console.log` statements that may have been used while working on a ticket.

Other things:
- Fixed `UploadLink.test.tsx` because it was throwing a warning.
- Removed `defaultValue` from `Searchbar` story ([link](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#no-longer-inferring-default-values-of-args))

### Screenshots
<img width="616" alt="Screen Shot 2023-01-23 at 3 47 23 PM" src="https://user-images.githubusercontent.com/47064971/214149497-e6507389-5211-4586-8739-3a1f0ce74678.png">

### Testing 
- Ran the Jest tests and looked at the output
