### PR TITLE
EVG-18664: Use Electron browser with Cypress

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -163,16 +163,6 @@ functions:
     params:
       directory: parsley
 
-  install-chrome:
-    command: shell.exec
-    params:
-      working_dir: parsley
-      script: |
-        cd /tmp
-        curl -L -o "chrome.zip" "${chrome_download_url}"
-        unzip chrome.zip
-        cd -
-
   send-email:
     command: shell.exec
     params:
@@ -215,7 +205,7 @@ functions:
       working_dir: parsley
       script: |
         export PATH=${node_path}
-        yarn cy:run --browser /tmp/chrome-linux/chrome --record --key ${cypress_record_key} --reporter junit
+        yarn cy:run --record --key ${cypress_record_key} --reporter junit
 
   yarn-eslint:
     command: shell.exec
@@ -415,7 +405,6 @@ tasks:
     - func: yarn-install
     - func: yarn-build
     - func: yarn-preview
-    - func: install-chrome
     - func: wait-for-evergreen
     - func: yarn-verify-backend
     - func: yarn-cypress

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Parsley is capable of fetching logs from both [evergreen](https://github.com/eve
 2. Run `yarn bootstrap-logkeeper` to download some sample resmoke logs from s3. 
 3. Run the command outputted by the previous step to seed the env variables and start the local logkeeper server 
 
-    `LK_CORS_ORIGINS=http:\/\/localhost:\\d+ LK_EVERGREEN_ORIGIN=http://localhost:8080 LK_PARSLEY_ORIGIN=http://localhost:5173 go run main/logkeeper.go --localPath {abs_path_to_parsley}/bin/_bucketdata` 
+    ```bash
+    LK_CORS_ORIGINS=http:\/\/localhost:\\d+ LK_EVERGREEN_ORIGIN=http://localhost:8080 LK_PARSLEY_ORIGIN=http://localhost:5173 go run main/logkeeper.go --localPath {abs_path_to_parsley}/bin/_bucketdata
+    ```
 
     Note that all log output is piped to a file named `logkeeperapp.log`.
     You can use `tail -f logkeeperapp.log` to view the log output

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
     supportFile: "cypress/support/index.ts",
     specPattern: "cypress/integration/**/*.ts",
     experimentalStudio: true,
-    numTestsKeptInMemory: 0,
   },
   reporterOptions: {
     mochaFile: "bin/cypress/cypress-[hash].xml",

--- a/cypress/integration/ansiiLogs/ansii_logView.ts
+++ b/cypress/integration/ansiiLogs/ansii_logView.ts
@@ -92,7 +92,6 @@ describe("Bookmarking and selecting lines", () => {
     const logLine297 =
       "[2022/03/02 17:05:21.050] running setup group because we have a new independent task";
 
-    cy.enableClipboard();
     cy.dataCy("details-button").click();
     cy.dataCy("jira-button-wrapper").click();
     cy.window().then((win) => {

--- a/cypress/integration/resmokeLogs/resmoke_logView.ts
+++ b/cypress/integration/resmokeLogs/resmoke_logView.ts
@@ -133,7 +133,6 @@ describe("Bookmarking and selecting lines", () => {
       "|ShardedClusterFixture:job0:mongos1        |j0:s1   |20010|73217|";
     const logLine11079 = `[j0:s1] | 2022-09-21T12:50:28.489+00:00 I  NETWORK  22944   [conn60] "Connection ended","attr":{"remote":"127.0.0.1:47362","uuid":{"uuid":{"$uuid":"b28d7d9f-03b6-4f93-a7cd-5e1948135f69"}},"connectionId":60,"connectionCount":2}`;
 
-    cy.enableClipboard();
     cy.dataCy("details-button").click();
     cy.dataCy("jira-button-wrapper").click();
     cy.window().then((win) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -79,19 +79,6 @@ Cypress.Commands.add(
   }
 );
 
-// Source: https://stackoverflow.com/questions/60174546/how-grant-cypress-test-application-some-permissions
-Cypress.Commands.add("enableClipboard", () => {
-  cy.wrap(
-    Cypress.automation("remote:debugger:protocol", {
-      command: "Browser.grantPermissions",
-      params: {
-        permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
-        origin: window.location.origin,
-      },
-    })
-  );
-});
-
 Cypress.Commands.add(
   "isContainedInViewport",
   { prevSubject: true },

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -37,10 +37,6 @@ declare global {
        * @example cy.editBounds({ lower: 5, upper: 10 })
        */
       editBounds(bounds: { upper?: string; lower?: string }): void;
-      /**
-       * Custom command to enable clipboard interactions.
-       */
-      enableClipboard(): void;
       /** Custom command to determine if an element is not contained in the viewport.
        * @example cy.isNotContainedInViewport()
        * @example cy.isNotContainedInViewport().should('be.visible')

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@typescript-eslint/parser": "5.48.0",
     "@vitejs/plugin-react": "3.0.0",
     "babel-loader": "8.2.5",
-    "cypress": "12.3.0",
+    "cypress": "12.4.0",
     "env-cmd": "10.1.0",
     "eslint": "8.31.0",
     "eslint-config-airbnb": "19.0.4",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@typescript-eslint/parser": "5.48.0",
     "@vitejs/plugin-react": "3.0.0",
     "babel-loader": "8.2.5",
-    "cypress": "12.4.0",
+    "cypress": "12.4.1",
     "env-cmd": "10.1.0",
     "eslint": "8.31.0",
     "eslint-config-airbnb": "19.0.4",

--- a/scripts/bootstrap-logkeeper.sh
+++ b/scripts/bootstrap-logkeeper.sh
@@ -23,7 +23,7 @@ if [ ! -d "bin/_bucketdata" ]; then
         echo "Please make sure you have the aws cli installed and configured."
         echo "See https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html for more information."
         echo "Cleaning up _bucketdata directory..."
-        rm -rf _bucketdata
+        rm -rf bin/_bucketdata
         exit 1
     fi
     # Uncompress the files in the _bucketdata directory

--- a/src/components/DetailsMenu/ButtonRow/index.tsx
+++ b/src/components/DetailsMenu/ButtonRow/index.tsx
@@ -33,9 +33,9 @@ const ButtonRow: React.FC = () => {
             <Button
               disabled={!bookmarks.length}
               leftGlyph={<Icon glyph="Copy" />}
-              onClick={() => {
+              onClick={async () => {
                 leaveBreadcrumb("copy-jira", { bookmarks }, "user");
-                copyToClipboard(getJiraFormat(bookmarks, getLine));
+                await copyToClipboard(getJiraFormat(bookmarks, getLine));
                 setHasCopied(!hasCopied);
                 sendEvent({ name: "Clicked Copy To Jira" });
               }}

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -2,8 +2,8 @@
  * `copyToClipboard` copies text to a user's clipboard.
  * @param textToCopy - text to be copied
  */
-export const copyToClipboard = (textToCopy: string) => {
-  navigator.clipboard.writeText(textToCopy);
+export const copyToClipboard = async (textToCopy: string) => {
+  await navigator.clipboard.writeText(textToCopy);
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6477,10 +6477,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==
 
-cypress@12.3.0:
-  version "12.3.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.3.0.tgz#ae3fb0540aef4b5eab1ef2bcd0760caf2992b8bf"
-  integrity sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==
+cypress@12.4.0:
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.4.0.tgz#de695bc51aec9d995456077a9c3e0ddadfb105c6"
+  integrity sha512-//h93K/yGC/7pxv1KamlkADbKHLp5h3f9rZDE2McRjXZDagMETH0sXowOOanvhsH8cFt/JWspIcK+p9cuaoAqg==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6477,10 +6477,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==
 
-cypress@12.4.0:
-  version "12.4.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.4.0.tgz#de695bc51aec9d995456077a9c3e0ddadfb105c6"
-  integrity sha512-//h93K/yGC/7pxv1KamlkADbKHLp5h3f9rZDE2McRjXZDagMETH0sXowOOanvhsH8cFt/JWspIcK+p9cuaoAqg==
+cypress@12.4.1:
+  version "12.4.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.4.1.tgz#6121b49fd7d833d1f4a0f486034f063467f433af"
+  integrity sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
EVG-18664

### Description 
<!-- Add description, context, thought process, etc -->
- OOM errors appear to have gone away for now, but [v12.4.0 added](https://docs.cypress.io/guides/references/changelog#12-4-0) an `experimentalMemoryManagement` flag that we can introduce if they pop up again
- Electron browser no longer requires enabling clipboard permissions
- Update `copyToClipboard` function since [`writeText()` is  async](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText)