### PR TITLE
EVG-18650: Upgrade Modal to v14.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@leafygreen-ui/guide-cue": "4.0.0",
     "@leafygreen-ui/icon-button": "15.0.1",
     "@leafygreen-ui/leafygreen-provider": "3.1.0",
-    "@leafygreen-ui/modal": "12.0.1",
+    "@leafygreen-ui/modal": "14.0.1",
     "@leafygreen-ui/palette": "3.4.4",
     "@leafygreen-ui/segmented-control": "7.0.0",
     "@leafygreen-ui/select": "10.1.0",

--- a/src/components/ShortcutModal/index.tsx
+++ b/src/components/ShortcutModal/index.tsx
@@ -90,7 +90,6 @@ const KeyTuple: React.FC<KeyTupleProps> = ({ keys }) => (
   </span>
 );
 
-// @ts-expect-error
 const StyledModal = styled(Modal)`
   z-index: ${zIndex.modal};
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2418,7 +2418,26 @@
   dependencies:
     lodash "^4.17.21"
 
-"@leafygreen-ui/modal@12.0.1", "@leafygreen-ui/modal@^12.0.0":
+"@leafygreen-ui/modal@14.0.1":
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/modal/-/modal-14.0.1.tgz#c5f1520af1e3a56f6474e182383699cefa6266ac"
+  integrity sha512-up+9eYYYNzbM1ZsfO/yRrjetd+AA1jElxtNJXjgYhz1Ow6T1cv+JJqLayMw2g1Rf2/hugzRmFOmVCQqhucrxFQ==
+  dependencies:
+    "@leafygreen-ui/emotion" "^4.0.3"
+    "@leafygreen-ui/hooks" "^7.3.3"
+    "@leafygreen-ui/icon" "^11.12.4"
+    "@leafygreen-ui/icon-button" "^15.0.4"
+    "@leafygreen-ui/lib" "^10.0.0"
+    "@leafygreen-ui/palette" "^3.4.7"
+    "@leafygreen-ui/portal" "^4.0.9"
+    "@leafygreen-ui/tokens" "^2.0.0"
+    facepaint "^1.2.1"
+    focus-trap-react "^8.10.0"
+    polished "^4.2.2"
+    prop-types "^15.8.1"
+    react-transition-group "^4.4.1"
+
+"@leafygreen-ui/modal@^12.0.0":
   version "12.0.1"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/modal/-/modal-12.0.1.tgz#80e0d538c18247498a489b16beb87f1a415725f3"
   integrity sha512-GIJGf4ys2n8TuU8rFEHa0juv3gE1JBf395v3gDNmimVZr/zkDTgcK6t8vWJ7PbCH9nX9s4BWUI7Ng6w2h7qTZw==


### PR DESCRIPTION
EVG-18650

### Description
This PR upgrades the Modal to v14.0.1 Changes include:
* Updates Modal for dark mode brand refresh. (v13)
* Modal now accepts a forwarded ref. In addition, it respects an `id` when the prop is set, rather than overwriting the value internally. (v14)

### Testing
- Clicked around and checked that things looked ok

