### PR TITLE
EVG-18815: Avoid corrupting big numbers in filters and highlights

### DIFF
--- a/src/hooks/useFilterParam/index.ts
+++ b/src/hooks/useFilterParam/index.ts
@@ -9,7 +9,9 @@ import { parseFilters, stringifyFilters } from "utils/query-string";
  * filters to and from URLs.
  */
 const useFilterParam = () => {
-  const [searchParams, setSearchParams] = useQueryParams();
+  const [searchParams, setSearchParams] = useQueryParams({
+    arrayFormat: "comma",
+  });
 
   const parsedFilters = parseFilters(
     conditionalCastToArray(searchParams.filters ?? [], true) as string[]

--- a/src/hooks/useHighlightParam/index.ts
+++ b/src/hooks/useHighlightParam/index.ts
@@ -6,12 +6,13 @@ import { conditionalCastToArray } from "utils/array";
  * `useHighlightParam` is a specialized form of useQueryParam. It needs to encode and decode the highlights
  */
 const useHighlightParam = () => {
-  const [searchParams, setSearchParams] = useQueryParams();
+  const [searchParams, setSearchParams] = useQueryParams({
+    arrayFormat: "comma",
+  });
   const parsedHighlights = useMemo(
     () =>
-      conditionalCastToArray(
-        (searchParams.highlights as string | string[] | null) ?? [],
-        true
+      (
+        conditionalCastToArray(searchParams.highlights ?? [], true) as string[]
       ).map((h) => decodeURIComponent(h)),
     [searchParams.highlights]
   );

--- a/src/hooks/useHighlightParam/useHighlightParam.test.tsx
+++ b/src/hooks/useHighlightParam/useHighlightParam.test.tsx
@@ -79,4 +79,13 @@ describe("useHighlightParam", () => {
       "failed",
     ]);
   });
+  it("should not corrupt large numerical values when decoding highlights from URL", () => {
+    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <MemoryRouter initialEntries={["/?highlights=1234567890123456789"]}>
+        {children}
+      </MemoryRouter>
+    );
+    const { result } = renderHook(() => useHighlightJointHook(), { wrapper });
+    expect(result.current.highlights).toStrictEqual(["1234567890123456789"]);
+  });
 });

--- a/src/hooks/useQueryParam/index.ts
+++ b/src/hooks/useQueryParam/index.ts
@@ -1,10 +1,11 @@
 import { useCallback } from "react";
+import { ParseOptions } from "query-string";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { conditionalCastToArray } from "utils/array";
 import { parseQueryString, stringifyQuery } from "utils/query-string";
 
 /** `useQueryParams` returns all of the query params passed into the url */
-const useQueryParams = () => {
+const useQueryParams = (parseOptions?: ParseOptions) => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const setQueryString = useCallback(
@@ -15,7 +16,10 @@ const useQueryParams = () => {
     [navigate]
   );
 
-  return [parseQueryString(searchParams.toString()), setQueryString] as const;
+  return [
+    parseQueryString(searchParams.toString(), parseOptions),
+    setQueryString,
+  ] as const;
 };
 
 /**

--- a/src/utils/query-string/index.ts
+++ b/src/utils/query-string/index.ts
@@ -1,13 +1,15 @@
-import { parse, stringify } from "query-string";
+import { ParseOptions, parse, stringify } from "query-string";
 import { CaseSensitivity, MatchType } from "constants/enums";
 import { Filters } from "types/logs";
 
-export const parseQueryString = (search: string) =>
-  parse(search, {
+export const parseQueryString = (
+  search: string,
+  options: ParseOptions = {
     arrayFormat: "comma",
     parseBooleans: true,
     parseNumbers: true,
-  });
+  }
+) => parse(search, options);
 
 export const stringifyQuery = (object: { [key: string]: any }) =>
   stringify(object, {


### PR DESCRIPTION
EVG-18815

### Description 
This PR addresses an issue where big numbers would get corrupted when read from the `filters` and `highlights` URL params.

The problem is that we specify `{ parseNumbers: true }` in the `parse` function from `query-string`. So if a very large number like `1234567890123456789` exists in the URL, it will attempt to parse it as a JavaScript number which results in `1234567890123456800`. For our purposes it's okay to parse these numbers as strings, so I modified the options we pass into the `parse` function for filters and highlights.

### Screenshots
<img width="266" alt="Screen Shot 2023-02-13 at 3 04 57 PM" src="https://user-images.githubusercontent.com/47064971/218563148-4c1e5f4e-c85e-4811-9d59-dbec6ec0b3f7.png">


### Testing 
- Manually tested the scenario described in the ticket on Beta environment (and made sure the filters and highlights actually work)
- Added tests in `useFilterParam.test.tsx` and `useHighlightParam.test.tsx`
