### PR TITLE
EVG-19026 Create ADR template

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,7 @@
+# Decisions
+
+This directory contains decision records for parsley.
+
+For new ADRs, please use [adr.md.template](adr.md.template) as basis.
+More information on MADR is available at <https://adr.github.io/madr/>.
+General information about architectural decision records is available at <https://adr.github.io/>.

--- a/docs/decisions/adr.md.template
+++ b/docs/decisions/adr.md.template
@@ -1,0 +1,18 @@
+# {short title of solved problem and solution}
+
+* status: {proposed | accepted | deprecated | superseded by [ADR-0005](0005-example.md)}
+* date: {YYYY-MM-DD when the decision was last updated}
+* authors: {list everyone involved in the decision}
+
+## Context and Problem Statement
+
+{Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story.
+ You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Considered Options
+
+## Decision Outcome
+
+<!-- This is an optional element. Feel free to remove. -->
+## More Information


### PR DESCRIPTION
EVG-19026

### Description
Creates a template for ADR's following @bsamek's format established in https://github.com/evergreen-ci/pine/tree/main/docs/decisions 

https://adr.github.io/