### PR TITLE
EVG-18944: Upgrade button

### DIFF
--- a/cypress/integration/ansiiLogs/ansii_logView.ts
+++ b/cypress/integration/ansiiLogs/ansii_logView.ts
@@ -89,7 +89,7 @@ describe("Bookmarking and selecting lines", () => {
       "[2022/03/02 17:05:21.050] running setup group because we have a new independent task";
 
     cy.dataCy("details-button").click();
-    cy.dataCy("jira-button-wrapper").click();
+    cy.dataCy("jira-button").click();
     cy.window().then((win) => {
       win.navigator.clipboard.readText().then((text) => {
         expect(text).to.eq(

--- a/cypress/integration/resmokeLogs/resmoke_logView.ts
+++ b/cypress/integration/resmokeLogs/resmoke_logView.ts
@@ -128,7 +128,7 @@ describe("Bookmarking and selecting lines", () => {
     const logLine11079 = `[j0:s1] | 2022-09-21T12:50:28.489+00:00 I  NETWORK  22944   [conn60] "Connection ended","attr":{"remote":"127.0.0.1:47362","uuid":{"uuid":{"$uuid":"b28d7d9f-03b6-4f93-a7cd-5e1948135f69"}},"connectionId":60,"connectionCount":2}`;
 
     cy.dataCy("details-button").click();
-    cy.dataCy("jira-button-wrapper").click();
+    cy.dataCy("jira-button").click();
     cy.window().then((win) => {
       win.navigator.clipboard.readText().then((text) => {
         expect(text).to.eq(

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -29,25 +29,21 @@ Cypress.Commands.add("addSearch", (search: string) => {
 });
 
 Cypress.Commands.add("clearBounds", () => {
-  cy.dataCy("details-button").click();
-  cy.get(`[data-cy="details-menu"]`).should("be.visible");
+  cy.toggleDetailsPanel(true);
 
   cy.dataCy("range-lower-bound").clear();
   cy.dataCy("range-upper-bound").clear();
 
-  cy.dataCy("details-button").click();
-  cy.get(`[data-cy="details-menu"]`).should("not.exist");
+  cy.toggleDetailsPanel(false);
 });
 
 Cypress.Commands.add(
   "clickToggle",
   (toggleDataCy: string, enabled: boolean) => {
-    cy.dataCy("details-button").click();
-    cy.get(`[data-cy="details-menu"]`).should("be.visible");
+    cy.toggleDetailsPanel(true);
     cy.dataCy(toggleDataCy).click();
     cy.dataCy(toggleDataCy).should("have.attr", "aria-checked", `${enabled}`);
-    cy.dataCy("details-button").click();
-    cy.get(`[data-cy="details-menu"]`).should("not.exist");
+    cy.toggleDetailsPanel(false);
   }
 );
 
@@ -58,8 +54,7 @@ Cypress.Commands.add("dataCy", (value: string) => {
 Cypress.Commands.add(
   "editBounds",
   (bounds: { upper: string; lower: string }) => {
-    cy.dataCy("details-button").click();
-    cy.get(`[data-cy="details-menu"]`).should("be.visible");
+    cy.toggleDetailsPanel(true);
 
     if (bounds.upper !== undefined) {
       cy.dataCy("range-upper-bound").should("be.visible");
@@ -71,8 +66,7 @@ Cypress.Commands.add(
       cy.dataCy("range-lower-bound").type(bounds.lower);
     }
 
-    cy.dataCy("details-button").click();
-    cy.get(`[data-cy="details-menu"]`).should("not.exist");
+    cy.toggleDetailsPanel(false);
   }
 );
 
@@ -152,14 +146,15 @@ Cypress.Commands.add("resetDrawerState", () => {
 });
 
 Cypress.Commands.add("toggleDetailsPanel", (open: boolean) => {
+  cy.dataCy("details-button").should("not.have.attr", "aria-disabled", "true");
   if (open) {
-    cy.get(`[data-cy="details-menu"]`).should("not.exist");
-    cy.get(`[data-cy="details-button"]`).click();
-    cy.get(`[data-cy="details-menu"]`).should("be.visible");
+    cy.dataCy("details-menu").should("not.exist");
+    cy.dataCy("details-button").click();
+    cy.dataCy("details-menu").should("be.visible");
   } else {
-    cy.get(`[data-cy="details-menu"]`).should("be.visible");
-    cy.get(`[data-cy="details-button"]`).click();
-    cy.get(`[data-cy="details-menu"]`).should("not.exist");
+    cy.dataCy("details-menu").should("be.visible");
+    cy.dataCy("details-button").click();
+    cy.dataCy("details-menu").should("not.exist");
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@emotion/styled": "11.10.5",
     "@leafygreen-ui/badge": "8.0.1",
     "@leafygreen-ui/banner": "7.0.1",
-    "@leafygreen-ui/button": "19.0.1",
+    "@leafygreen-ui/button": "20.0.0",
     "@leafygreen-ui/card": "9.0.2",
     "@leafygreen-ui/confirmation-modal": "4.0.3",
     "@leafygreen-ui/emotion": "4.0.3",

--- a/src/components/DetailsMenu/ButtonRow/ButtonRow.test.tsx
+++ b/src/components/DetailsMenu/ButtonRow/ButtonRow.test.tsx
@@ -16,12 +16,12 @@ describe("buttonRow", () => {
       renderWithRouterMatch(<ButtonRow />, {
         wrapper: wrapper(logLines),
       });
-      const jiraButton = screen.getByRole("button", {
-        name: "JIRA",
-      });
-      expect(jiraButton).toBeDisabled();
+      expect(screen.getByDataCy("jira-button")).toHaveAttribute(
+        "aria-disabled",
+        "true"
+      );
       // Tooltip should appear even if button is disabled.
-      await user.hover(screen.getByDataCy("jira-button-wrapper"));
+      await user.hover(screen.getByDataCy("jira-button"));
       await waitFor(() => {
         expect(screen.getByText("No bookmarks to copy.")).toBeInTheDocument();
       });
@@ -32,9 +32,7 @@ describe("buttonRow", () => {
         wrapper: wrapper(logLines),
         route: "?bookmarks=0,2",
       });
-      const jiraButton = screen.getByRole("button", {
-        name: "JIRA",
-      });
+      const jiraButton = screen.getByDataCy("jira-button");
       expect(jiraButton).toBeEnabled();
       // Tooltip text should appear on hover.
       await user.hover(jiraButton);
@@ -61,9 +59,7 @@ describe("buttonRow", () => {
         route: "?bookmarks=0,2,5",
       });
 
-      const jiraButton = screen.getByRole("button", {
-        name: "JIRA",
-      });
+      const jiraButton = screen.getByDataCy("jira-button");
       expect(jiraButton).toBeEnabled();
 
       await user.click(jiraButton);

--- a/src/components/DetailsMenu/ButtonRow/index.tsx
+++ b/src/components/DetailsMenu/ButtonRow/index.tsx
@@ -28,22 +28,19 @@ const ButtonRow: React.FC = () => {
         align="top"
         justify="middle"
         trigger={
-          // We need to wrap the button in a div because mouse events are not triggered on
-          // disabled elements.
-          <div data-cy="jira-button-wrapper">
-            <Button
-              disabled={!bookmarks.length}
-              leftGlyph={<Icon glyph="Copy" />}
-              onClick={async () => {
-                leaveBreadcrumb("copy-jira", { bookmarks }, "user");
-                await copyToClipboard(getJiraFormat(bookmarks, getLine));
-                setHasCopied(!hasCopied);
-                sendEvent({ name: "Clicked Copy To Jira" });
-              }}
-            >
-              JIRA
-            </Button>
-          </div>
+          <Button
+            data-cy="jira-button"
+            disabled={!bookmarks.length}
+            leftGlyph={<Icon glyph="Copy" />}
+            onClick={async () => {
+              leaveBreadcrumb("copy-jira", { bookmarks }, "user");
+              await copyToClipboard(getJiraFormat(bookmarks, getLine));
+              setHasCopied(!hasCopied);
+              sendEvent({ name: "Clicked Copy To Jira" });
+            }}
+          >
+            JIRA
+          </Button>
         }
         triggerEvent="hover"
       >
@@ -53,18 +50,16 @@ const ButtonRow: React.FC = () => {
         align="top"
         justify="middle"
         trigger={
-          <div data-cy="job-logs-button-wrapper">
-            <Button
-              data-cy="job-logs-button"
-              disabled={!jobLogsURL}
-              href={jobLogsURL}
-              leftGlyph={<Icon glyph="Export" />}
-              onClick={() => sendEvent({ name: "Opened Job Logs" })}
-              target="_blank"
-            >
-              Job Logs
-            </Button>
-          </div>
+          <Button
+            data-cy="job-logs-button"
+            disabled={!jobLogsURL}
+            href={jobLogsURL}
+            leftGlyph={<Icon glyph="Export" />}
+            onClick={() => sendEvent({ name: "Opened Job Logs" })}
+            target="_blank"
+          >
+            Job Logs
+          </Button>
         }
       >
         View all logs for this job
@@ -73,18 +68,16 @@ const ButtonRow: React.FC = () => {
         align="top"
         justify="middle"
         trigger={
-          <div data-cy="raw-logs-button-wrapper">
-            <Button
-              data-cy="raw-log-button"
-              disabled={!rawLogURL}
-              href={rawLogURL}
-              leftGlyph={<Icon glyph="Export" />}
-              onClick={() => sendEvent({ name: "Opened Raw Logs" })}
-              target="_blank"
-            >
-              Raw
-            </Button>
-          </div>
+          <Button
+            data-cy="raw-log-button"
+            disabled={!rawLogURL}
+            href={rawLogURL}
+            leftGlyph={<Icon glyph="Export" />}
+            onClick={() => sendEvent({ name: "Opened Raw Logs" })}
+            target="_blank"
+          >
+            Raw
+          </Button>
         }
       >
         Open Raw log in a new tab
@@ -93,18 +86,16 @@ const ButtonRow: React.FC = () => {
         align="top"
         justify="middle"
         trigger={
-          <div data-cy="html-logs-button-wrapper">
-            <Button
-              data-cy="html-log-button"
-              disabled={!htmlLogURL}
-              href={htmlLogURL}
-              leftGlyph={<Icon glyph="Export" />}
-              onClick={() => sendEvent({ name: "Opened HTML Logs" })}
-              target="_blank"
-            >
-              HTML
-            </Button>
-          </div>
+          <Button
+            data-cy="html-log-button"
+            disabled={!htmlLogURL}
+            href={htmlLogURL}
+            leftGlyph={<Icon glyph="Export" />}
+            onClick={() => sendEvent({ name: "Opened HTML Logs" })}
+            target="_blank"
+          >
+            HTML
+          </Button>
         }
       >
         Open log in standard HTML format in a new tab
@@ -113,18 +104,16 @@ const ButtonRow: React.FC = () => {
         align="top"
         justify="middle"
         trigger={
-          <div data-cy="lobster-button-wrapper">
-            <Button
-              data-cy="lobster-button"
-              disabled={!lobsterURL}
-              href={lobsterURL}
-              leftGlyph={<Icon glyph="Export" />}
-              onClick={() => sendEvent({ name: "Opened Lobster Logs" })}
-              target="_blank"
-            >
-              Lobster
-            </Button>
-          </div>
+          <Button
+            data-cy="lobster-button"
+            disabled={!lobsterURL}
+            href={lobsterURL}
+            leftGlyph={<Icon glyph="Export" />}
+            onClick={() => sendEvent({ name: "Opened Lobster Logs" })}
+            target="_blank"
+          >
+            Lobster
+          </Button>
         }
       >
         View the log using the legacy logviewer in a new tab

--- a/src/components/DetailsMenu/__snapshots__/DetailsMenu.stories.storyshot
+++ b/src/components/DetailsMenu/__snapshots__/DetailsMenu.stories.storyshot
@@ -355,212 +355,183 @@ exports[`storyshots Storyshots components/DetailsMenu Default 1`] = `
       <div
         class="css-91jh6a"
       >
-        <div
-          class="leafygreen-ui-cssveg"
-          data-cy="jira-button-wrapper"
+        <button
+          aria-disabled="true"
+          class="lg-ui-button-0000 leafygreen-ui-10mo38b"
+          data-cy="jira-button"
+          type="button"
         >
-          <button
-            aria-disabled="true"
-            class="lg-ui-button-0000 leafygreen-ui-e1tz2b"
-            disabled=""
-            type="button"
+          <div
+            class="leafygreen-ui-v038xi"
+          />
+          <div
+            class="leafygreen-ui-1qmzz4y"
           >
-            <div
-              class="leafygreen-ui-v038xi"
-            />
-            <div
-              class="leafygreen-ui-1qmzz4y"
+            <svg
+              alt=""
+              aria-hidden="true"
+              class="leafygreen-ui-169mpis"
+              fill="none"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                alt=""
-                aria-hidden="true"
-                class="leafygreen-ui-169mpis"
-                fill="none"
-                height="16"
-                role="presentation"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  clip-rule="evenodd"
-                  d="M1 5.714v4.572C1 11.233 1.768 12 2.714 12H5.75V7.11c0-.566.227-1.108.63-1.504l2.294-2.252c.1-.099.21-.186.326-.262v-.378C9 1.768 8.232 1 7.286 1H5.8v3.429c0 .71-.576 1.285-1.286 1.285H1zm8-.928L7.257 6.498A.857.857 0 007 7.11v.688h3.01a.857.857 0 00.857-.858V4h-.717a.857.857 0 00-.6.246l-.55.54zM4.867 1H4.15a.857.857 0 00-.601.246L1.257 3.498A.857.857 0 001 4.11v.688h3.01a.857.857 0 00.857-.858V1zM7 12V8.714H10.514c.71 0 1.286-.575 1.286-1.285V4h1.486C14.233 4 15 4.768 15 5.714v7.572c0 .947-.768 1.714-1.714 1.714H8.714A1.714 1.714 0 017 13.286V12z"
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              JIRA
-            </div>
-          </button>
-        </div>
-        <div
-          class="leafygreen-ui-cssveg"
-          data-cy="job-logs-button-wrapper"
+              <path
+                clip-rule="evenodd"
+                d="M1 5.714v4.572C1 11.233 1.768 12 2.714 12H5.75V7.11c0-.566.227-1.108.63-1.504l2.294-2.252c.1-.099.21-.186.326-.262v-.378C9 1.768 8.232 1 7.286 1H5.8v3.429c0 .71-.576 1.285-1.286 1.285H1zm8-.928L7.257 6.498A.857.857 0 007 7.11v.688h3.01a.857.857 0 00.857-.858V4h-.717a.857.857 0 00-.6.246l-.55.54zM4.867 1H4.15a.857.857 0 00-.601.246L1.257 3.498A.857.857 0 001 4.11v.688h3.01a.857.857 0 00.857-.858V1zM7 12V8.714H10.514c.71 0 1.286-.575 1.286-1.285V4h1.486C14.233 4 15 4.768 15 5.714v7.572c0 .947-.768 1.714-1.714 1.714H8.714A1.714 1.714 0 017 13.286V12z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+            JIRA
+          </div>
+        </button>
+        <button
+          aria-disabled="true"
+          class="lg-ui-button-0000 leafygreen-ui-10mo38b"
+          data-cy="job-logs-button"
+          target="_blank"
+          type="button"
         >
-          <button
-            aria-disabled="true"
-            class="lg-ui-button-0000 leafygreen-ui-e1tz2b"
-            data-cy="job-logs-button"
-            disabled=""
-            target="_blank"
-            type="button"
+          <div
+            class="leafygreen-ui-v038xi"
+          />
+          <div
+            class="leafygreen-ui-1qmzz4y"
           >
-            <div
-              class="leafygreen-ui-v038xi"
-            />
-            <div
-              class="leafygreen-ui-1qmzz4y"
+            <svg
+              alt=""
+              aria-hidden="true"
+              class="leafygreen-ui-169mpis"
+              fill="none"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                alt=""
-                aria-hidden="true"
-                class="leafygreen-ui-169mpis"
-                fill="none"
-                height="16"
-                role="presentation"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M14.623 5.186a.278.278 0 000-.385l-2.805-2.915a.277.277 0 00-.477.192v1.424A6.5 6.5 0 005 10v.1a1.5 1.5 0 003 0V10a3.5 3.5 0 013.34-3.496v1.405c0 .25.305.373.478.193l2.805-2.916z"
-                  fill="currentColor"
-                />
-                <path
-                  d="M6.5 3.879a.75.75 0 00-.75-.75H4a2 2 0 00-2 2v6.864a2 2 0 002 2h6.864a2 2 0 002-2V10.05a.75.75 0 00-1.5 0v1.943a.5.5 0 01-.5.5H4a.5.5 0 01-.5-.5V5.129a.5.5 0 01.5-.5h1.75a.75.75 0 00.75-.75z"
-                  fill="currentColor"
-                />
-              </svg>
-              Job Logs
-            </div>
-          </button>
-        </div>
-        <div
-          class="leafygreen-ui-cssveg"
-          data-cy="raw-logs-button-wrapper"
+              <path
+                d="M14.623 5.186a.278.278 0 000-.385l-2.805-2.915a.277.277 0 00-.477.192v1.424A6.5 6.5 0 005 10v.1a1.5 1.5 0 003 0V10a3.5 3.5 0 013.34-3.496v1.405c0 .25.305.373.478.193l2.805-2.916z"
+                fill="currentColor"
+              />
+              <path
+                d="M6.5 3.879a.75.75 0 00-.75-.75H4a2 2 0 00-2 2v6.864a2 2 0 002 2h6.864a2 2 0 002-2V10.05a.75.75 0 00-1.5 0v1.943a.5.5 0 01-.5.5H4a.5.5 0 01-.5-.5V5.129a.5.5 0 01.5-.5h1.75a.75.75 0 00.75-.75z"
+                fill="currentColor"
+              />
+            </svg>
+            Job Logs
+          </div>
+        </button>
+        <button
+          aria-disabled="true"
+          class="lg-ui-button-0000 leafygreen-ui-10mo38b"
+          data-cy="raw-log-button"
+          target="_blank"
+          type="button"
         >
-          <button
-            aria-disabled="true"
-            class="lg-ui-button-0000 leafygreen-ui-e1tz2b"
-            data-cy="raw-log-button"
-            disabled=""
-            target="_blank"
-            type="button"
+          <div
+            class="leafygreen-ui-v038xi"
+          />
+          <div
+            class="leafygreen-ui-1qmzz4y"
           >
-            <div
-              class="leafygreen-ui-v038xi"
-            />
-            <div
-              class="leafygreen-ui-1qmzz4y"
+            <svg
+              alt=""
+              aria-hidden="true"
+              class="leafygreen-ui-169mpis"
+              fill="none"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                alt=""
-                aria-hidden="true"
-                class="leafygreen-ui-169mpis"
-                fill="none"
-                height="16"
-                role="presentation"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M14.623 5.186a.278.278 0 000-.385l-2.805-2.915a.277.277 0 00-.477.192v1.424A6.5 6.5 0 005 10v.1a1.5 1.5 0 003 0V10a3.5 3.5 0 013.34-3.496v1.405c0 .25.305.373.478.193l2.805-2.916z"
-                  fill="currentColor"
-                />
-                <path
-                  d="M6.5 3.879a.75.75 0 00-.75-.75H4a2 2 0 00-2 2v6.864a2 2 0 002 2h6.864a2 2 0 002-2V10.05a.75.75 0 00-1.5 0v1.943a.5.5 0 01-.5.5H4a.5.5 0 01-.5-.5V5.129a.5.5 0 01.5-.5h1.75a.75.75 0 00.75-.75z"
-                  fill="currentColor"
-                />
-              </svg>
-              Raw
-            </div>
-          </button>
-        </div>
-        <div
-          class="leafygreen-ui-cssveg"
-          data-cy="html-logs-button-wrapper"
+              <path
+                d="M14.623 5.186a.278.278 0 000-.385l-2.805-2.915a.277.277 0 00-.477.192v1.424A6.5 6.5 0 005 10v.1a1.5 1.5 0 003 0V10a3.5 3.5 0 013.34-3.496v1.405c0 .25.305.373.478.193l2.805-2.916z"
+                fill="currentColor"
+              />
+              <path
+                d="M6.5 3.879a.75.75 0 00-.75-.75H4a2 2 0 00-2 2v6.864a2 2 0 002 2h6.864a2 2 0 002-2V10.05a.75.75 0 00-1.5 0v1.943a.5.5 0 01-.5.5H4a.5.5 0 01-.5-.5V5.129a.5.5 0 01.5-.5h1.75a.75.75 0 00.75-.75z"
+                fill="currentColor"
+              />
+            </svg>
+            Raw
+          </div>
+        </button>
+        <button
+          aria-disabled="true"
+          class="lg-ui-button-0000 leafygreen-ui-10mo38b"
+          data-cy="html-log-button"
+          target="_blank"
+          type="button"
         >
-          <button
-            aria-disabled="true"
-            class="lg-ui-button-0000 leafygreen-ui-e1tz2b"
-            data-cy="html-log-button"
-            disabled=""
-            target="_blank"
-            type="button"
+          <div
+            class="leafygreen-ui-v038xi"
+          />
+          <div
+            class="leafygreen-ui-1qmzz4y"
           >
-            <div
-              class="leafygreen-ui-v038xi"
-            />
-            <div
-              class="leafygreen-ui-1qmzz4y"
+            <svg
+              alt=""
+              aria-hidden="true"
+              class="leafygreen-ui-169mpis"
+              fill="none"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                alt=""
-                aria-hidden="true"
-                class="leafygreen-ui-169mpis"
-                fill="none"
-                height="16"
-                role="presentation"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M14.623 5.186a.278.278 0 000-.385l-2.805-2.915a.277.277 0 00-.477.192v1.424A6.5 6.5 0 005 10v.1a1.5 1.5 0 003 0V10a3.5 3.5 0 013.34-3.496v1.405c0 .25.305.373.478.193l2.805-2.916z"
-                  fill="currentColor"
-                />
-                <path
-                  d="M6.5 3.879a.75.75 0 00-.75-.75H4a2 2 0 00-2 2v6.864a2 2 0 002 2h6.864a2 2 0 002-2V10.05a.75.75 0 00-1.5 0v1.943a.5.5 0 01-.5.5H4a.5.5 0 01-.5-.5V5.129a.5.5 0 01.5-.5h1.75a.75.75 0 00.75-.75z"
-                  fill="currentColor"
-                />
-              </svg>
-              HTML
-            </div>
-          </button>
-        </div>
-        <div
-          class="leafygreen-ui-cssveg"
-          data-cy="lobster-button-wrapper"
+              <path
+                d="M14.623 5.186a.278.278 0 000-.385l-2.805-2.915a.277.277 0 00-.477.192v1.424A6.5 6.5 0 005 10v.1a1.5 1.5 0 003 0V10a3.5 3.5 0 013.34-3.496v1.405c0 .25.305.373.478.193l2.805-2.916z"
+                fill="currentColor"
+              />
+              <path
+                d="M6.5 3.879a.75.75 0 00-.75-.75H4a2 2 0 00-2 2v6.864a2 2 0 002 2h6.864a2 2 0 002-2V10.05a.75.75 0 00-1.5 0v1.943a.5.5 0 01-.5.5H4a.5.5 0 01-.5-.5V5.129a.5.5 0 01.5-.5h1.75a.75.75 0 00.75-.75z"
+                fill="currentColor"
+              />
+            </svg>
+            HTML
+          </div>
+        </button>
+        <button
+          aria-disabled="true"
+          class="lg-ui-button-0000 leafygreen-ui-10mo38b"
+          data-cy="lobster-button"
+          target="_blank"
+          type="button"
         >
-          <button
-            aria-disabled="true"
-            class="lg-ui-button-0000 leafygreen-ui-e1tz2b"
-            data-cy="lobster-button"
-            disabled=""
-            target="_blank"
-            type="button"
+          <div
+            class="leafygreen-ui-v038xi"
+          />
+          <div
+            class="leafygreen-ui-1qmzz4y"
           >
-            <div
-              class="leafygreen-ui-v038xi"
-            />
-            <div
-              class="leafygreen-ui-1qmzz4y"
+            <svg
+              alt=""
+              aria-hidden="true"
+              class="leafygreen-ui-169mpis"
+              fill="none"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                alt=""
-                aria-hidden="true"
-                class="leafygreen-ui-169mpis"
-                fill="none"
-                height="16"
-                role="presentation"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M14.623 5.186a.278.278 0 000-.385l-2.805-2.915a.277.277 0 00-.477.192v1.424A6.5 6.5 0 005 10v.1a1.5 1.5 0 003 0V10a3.5 3.5 0 013.34-3.496v1.405c0 .25.305.373.478.193l2.805-2.916z"
-                  fill="currentColor"
-                />
-                <path
-                  d="M6.5 3.879a.75.75 0 00-.75-.75H4a2 2 0 00-2 2v6.864a2 2 0 002 2h6.864a2 2 0 002-2V10.05a.75.75 0 00-1.5 0v1.943a.5.5 0 01-.5.5H4a.5.5 0 01-.5-.5V5.129a.5.5 0 01.5-.5h1.75a.75.75 0 00.75-.75z"
-                  fill="currentColor"
-                />
-              </svg>
-              Lobster
-            </div>
-          </button>
-        </div>
+              <path
+                d="M14.623 5.186a.278.278 0 000-.385l-2.805-2.915a.277.277 0 00-.477.192v1.424A6.5 6.5 0 005 10v.1a1.5 1.5 0 003 0V10a3.5 3.5 0 013.34-3.496v1.405c0 .25.305.373.478.193l2.805-2.916z"
+                fill="currentColor"
+              />
+              <path
+                d="M6.5 3.879a.75.75 0 00-.75-.75H4a2 2 0 00-2 2v6.864a2 2 0 002 2h6.864a2 2 0 002-2V10.05a.75.75 0 00-1.5 0v1.943a.5.5 0 01-.5.5H4a.5.5 0 01-.5-.5V5.129a.5.5 0 01.5-.5h1.75a.75.75 0 00.75-.75z"
+                fill="currentColor"
+              />
+            </svg>
+            Lobster
+          </div>
+        </button>
       </div>
     </div>
   </div>

--- a/src/components/LogRow/CollapsedRow/CollapsedRow.test.tsx
+++ b/src/components/LogRow/CollapsedRow/CollapsedRow.test.tsx
@@ -86,7 +86,7 @@ describe("collapsedRow", () => {
     const expandFiveButton = screen.getByRole("button", {
       name: "Expand Icon 5 Above and Below",
     });
-    expect(expandFiveButton).not.toBeDisabled();
+    expect(expandFiveButton).not.toHaveAttribute("aria-disabled", "true");
   });
 });
 

--- a/src/components/PopoverButton/__snapshots__/PopoverButton.stories.storyshot
+++ b/src/components/PopoverButton/__snapshots__/PopoverButton.stories.storyshot
@@ -4,7 +4,7 @@ exports[`storyshots Storyshots components/PopoverButton Default 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="lg-ui-button-0000 leafygreen-ui-1t94nwe"
+    class="lg-ui-button-0000 leafygreen-ui-1kt1vpf"
     type="button"
   >
     <div

--- a/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/FilterGroup.test.tsx
+++ b/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/FilterGroup.test.tsx
@@ -87,9 +87,9 @@ describe("filters", () => {
     const confirmButton = screen.getByRole("button", {
       name: "Apply",
     });
-    expect(confirmButton).toBeDisabled();
+    expect(confirmButton).toHaveAttribute("aria-disabled", "true");
     await user.clear(screen.getByDataCy("edit-filter-name"));
-    expect(confirmButton).toBeDisabled();
+    expect(confirmButton).toHaveAttribute("aria-disabled", "true");
   });
 
   it("should toggle between visibility icons when they are clicked", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2279,7 +2279,20 @@
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/box/-/box-3.1.1.tgz#3d2cc09ac5105e19d2a49da2f2065b45cc8e4722"
   integrity sha512-zA6Ors7GV19DTVLqhQdg3jvypUNlyNJNVrS2XytmsPvR5XJuh5saNLmi9zw1aNsN7hETUCxj4JH1QxDEgaYTqg==
 
-"@leafygreen-ui/button@19.0.1", "@leafygreen-ui/button@^19.0.1":
+"@leafygreen-ui/button@20.0.0":
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/button/-/button-20.0.0.tgz#862ae0c66b8d5d0d3575caf8093b74c17bd62e9e"
+  integrity sha512-MRLgkUE3bFum5rP4+g2zLPvdRMRN9TgORnbNU4E5vIug11/jlKeLLh2M4yPJo8Ko6bUEeDcW5sb5OBo0SFmVqA==
+  dependencies:
+    "@leafygreen-ui/box" "^3.1.1"
+    "@leafygreen-ui/emotion" "^4.0.3"
+    "@leafygreen-ui/lib" "^10.1.0"
+    "@leafygreen-ui/palette" "^3.4.7"
+    "@leafygreen-ui/ripple" "^1.1.8"
+    "@leafygreen-ui/tokens" "^2.0.0"
+    polished "^4.2.2"
+
+"@leafygreen-ui/button@^19.0.1":
   version "19.0.1"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/button/-/button-19.0.1.tgz#76b927abcd246d23b99963aa73f2cec3eb465526"
   integrity sha512-RXD+Y37LSL3Wc2gDAqIOCznYcuwxWpm/KY7w2wEie9Okj0OFPf6v5haBTvtrBF8opq0RepXM/KYEWVgKYVOWoQ==
@@ -2416,6 +2429,13 @@
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/lib/-/lib-10.0.0.tgz#082155cbea1698ea1feb20ebbf9eec8f4b45ddc7"
   integrity sha512-l9W05IYJ/Bmyu5TayuadlsSR1DTF3W05o8Lk6HQk1qK+1xMLMwrxysbwzI6jKb6wAALU9/1dmw9kLDKE2n+EWg==
+  dependencies:
+    lodash "^4.17.21"
+
+"@leafygreen-ui/lib@^10.1.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/lib/-/lib-10.2.0.tgz#789cf8e5cd1a23da1766d7fd0ba2b5f325badf2f"
+  integrity sha512-XrqBEyb41si4/Am8Cu2KcgAvd9xGj1bBqnwtHK0qmNlyifRM46DSxAnPXCH7S9J+Jl+AhhZ9DFNDk7+CtIieHg==
   dependencies:
     lodash "^4.17.21"
 


### PR DESCRIPTION
EVG-18944

### Description 
<!-- Add description, context, thought process, etc -->
- Changes in https://github.com/mongodb/leafygreen-ui/pull/1611 mean that we don't need to use wrappers around buttons that function as tooltip triggers. Previously the wrapper was required or else a disabled button would block tooltip rendering.
- The package changes also mean that we need to check for the `aria-disabled` attribute instead of just using Cypress/React Testing Library's "disabled" check. There are some details [here](https://github.com/mongodb/leafygreen-ui/pull/1611#discussion_r1099090020).

### Testing 
<!-- Add a description of how you tested it -->
- Update tests