### PR TITLE
EVG-19038 Copy wiki to docs/ directory

### DIFF
--- a/docs/Highlighting,-Bookmarking-and-sharing.md
+++ b/docs/Highlighting,-Bookmarking-and-sharing.md
@@ -1,0 +1,20 @@
+Add Highlight can help call attention to log lines matching a specific regexp by highlighting matching terms. 
+
+You can add multiple highlights concurrently. If you want to remove highlights, you can do so through the side panel.  
+
+![highlight manager](https://user-images.githubusercontent.com/624531/207638301-25e579cd-fb4c-483a-aaf7-da0544833e6d.png)
+
+Bookmarks:
+You can bookmark a line by double-clicking on any part of the log line except the link icon. You can then navigate to your bookmarked lines by clicking on the corresponding line number in the bookmark pane.
+The clear button at the top of the bookmark pane clears all bookmarks.
+
+![bookmarks](https://user-images.githubusercontent.com/624531/207638338-cb3256f8-83bb-4a50-9e40-82cfff261020.png)
+
+Bookmarked lines can also be copied to your local clipboard in JIRA formatting. To copy bookmarked text, click on the Jira button in the details menu. This button will copy the text content of all bookmarks of the current log file, sandwiched between {noformat} tags so they can be pasted into any JIRA ticket as monospaced text.
+
+![jira](https://user-images.githubusercontent.com/624531/207638364-d9161fbb-1885-4d1a-9b33-f062165fd40f.png)
+
+Sharing log lines
+To share a particular log line with others, click on the link icon next to the log line. This will save the line in the URL and highlight the log line. Loading that URL will jump to the linked line.
+
+![selected line](https://user-images.githubusercontent.com/624531/207638392-d75f9dd5-d898-41c0-b849-076238813b4c.png)

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,10 @@
+Parsley is the successor to Lobster, Evergreen’s log viewer.  Parsley borrows several design elements from Lobster but there are some key differences between the two log viewers.  This page will walk through Parsley’s interface and key features. 
+
+
+* [Interface](Interface)
+* [Searching and filtering](Searching-and-filtering)
+* [Bookmarking and sharing](Highlighting,-Bookmarking-and-sharing)
+* [Navigating to other pages](Navigating-to-other-pages.)
+* [Keyboard Shortcuts](Keyboard-Shortcuts)
+* [Local Logs](Local-Logs)
+

--- a/docs/Interface.md
+++ b/docs/Interface.md
@@ -1,0 +1,17 @@
+Interface: 
+
+The Parsley log viewer consists of a few major components listed below:
+
+![interface](https://user-images.githubusercontent.com/624531/207629901-f8939ce3-2073-4c86-87d1-5708e7258a7e.jpg)
+
+**Search bar:** The dropdown provides three modes: search, filter, and highlight. You can write a regex expression in the text input and press enter to apply the search, filter, or highlight.
+
+**Side Panel:** The side panel is where you can manage your filters, expanded lines, and highlighted terms. The side panel is collapsible. Hovering over the collapsed side panel will expand it temporarily.
+
+**Bookmark Pane:** The bookmark pane contains your bookmarks and share line. Click on any of the line numbers to automatically jump to that log line.
+
+**Log Pane:** The log pane contains the log text. You can interact with the pane by double clicking any log line, which adds the log line to your bookmarks, or by clicking the link icons, which designates that log line as a line to share in the URL.
+
+**Details menu:** The menu provides a variety of togglable settings which can affect the log view as well as the functionality of searching and filtering. These settings will be discussed in detail in further sections. The menu also provides external links to the raw and HTML logs.
+
+Each component is also covered in detail in further sections. 

--- a/docs/Keyboard-Shortcuts.md
+++ b/docs/Keyboard-Shortcuts.md
@@ -1,0 +1,11 @@
+Parsley lets you perform certain tasks directly from the keyboard.
+
+Pressing `Shift` and `?` brings up the shortcut menu for Parsley: 
+
+`Ctrl` + `F` or `Cmd` + `F` moves the cursor to the search bar. 
+
+`Ctrl `+ `S` or `Cmd` + `S` cycles between search filter and highlight. 
+
+`]` switches between displaying and hiding the side panel. 
+
+`N` and `P` paginate forward and backward for search results. 

--- a/docs/Local-Logs.md
+++ b/docs/Local-Logs.md
@@ -1,0 +1,14 @@
+You can also upload local log files on Parsley.
+
+
+Upon clicking the button, you will see a box to drag and drop local files. You can also select a file using  a file picker if you click the "Select from Files" button.
+
+![box](https://user-images.githubusercontent.com/624531/207638805-5da6f83c-5f54-419d-a301-794516898a66.png)
+
+Once a local log file is uploaded, you can choose how to parse your logs. The options are as follows:.   
+Raw: Logs do not have server-specific color coding, and will apply minimal ANSII processing. Typically choose this one if you're not looking at a resmoke log.
+
+![unnamed](https://user-images.githubusercontent.com/624531/207638830-6ff987f5-5fca-4eb1-ab91-a4ae0b1080c7.png)
+
+Resmoke: Logs have color coding to differentiate between individual config server nodes, replica set nodes, mongos, etc.  that the logs are coming from.
+

--- a/docs/Navigating-to-other-pages..md
+++ b/docs/Navigating-to-other-pages..md
@@ -1,0 +1,15 @@
+The task page link above the log links to the task page on Spruce. 
+
+![task page](https://user-images.githubusercontent.com/624531/207638552-0119b374-2e16-490b-80a2-e1cdab1dd21d.png)
+
+Raw and HTML buttons in the details menu links to the raw and HTML versions of the current log. 
+
+![raw and html](https://user-images.githubusercontent.com/624531/207638591-69a596d4-9578-40b3-8dbf-3fc84230040a.png)
+
+Job Logs Page
+
+Resmoke.py – the test runner for mongodb-mongo-* tests – has a concept of a 'job' for organizing groups of tests to run. mongodb-mongo* logs include a “Job Logs” button that allows you to view all logs within a single job.  
+
+The Job Logs button links to the Jobs Log page on Spruce for the current test.
+
+![job logs](https://user-images.githubusercontent.com/624531/207638619-4eaf1c55-c71d-47ad-97f1-5826c38cc4f9.png)

--- a/docs/Searching-and-filtering.md
+++ b/docs/Searching-and-filtering.md
@@ -1,0 +1,57 @@
+**Line Wrapping:** 
+Log lines can be wrapped/unwrapped by toggling the wrap button under show details. 
+
+![wrap](https://user-images.githubusercontent.com/624531/207634738-6cde452e-4c0c-46e1-a9d8-01aa3b3dae20.png)
+
+**Search: **
+
+To search for a term in a log, enter a regexp search term in the search bar with the "Search" mode active. Hit enter to navigate to the first appearance of the term. You can paginate through the search results by either manually clicking on the next and previous buttons, or using the n and p keys on your keyboard. 
+
+![search example](https://user-images.githubusercontent.com/624531/207634781-776f1cd4-a261-4d44-bb36-f29a62a13847.png)
+
+As seen above, search is case insensitive by default. Open the details menu to toggle to turn case sensitivity on and off. Note that the case sensitivity toggle only affects searching, having no effect on filtering or highlighting. 
+
+![case sensetive](https://user-images.githubusercontent.com/624531/207634810-65b64124-1c52-4cd5-a45c-dd9a41906f4f.png)
+
+You can limit your search between the certain lines by specifying a range in the details menu. 
+ 
+![range](https://user-images.githubusercontent.com/624531/207634831-130847b4-ce1c-43b2-973f-989b5de3a2a1.png)
+
+**Filters: **
+To apply a filter, enter a regexp search term in the search bar with the "Filter" mode active. 
+
+![filter name](https://user-images.githubusercontent.com/624531/207634860-7197c4b3-ae82-499a-922e-878cbaa1e0bd.png)
+
+There are several options associated with a filter, which are described below:
+
+Edit filter: Click the pencil icon next to the filter to edit the filter term.
+
+Delete filter: Click the X icon to remove a filter. 
+
+Toggle visibility: Click the eye icon to hide or show a filter.
+
+Toggle case sensitivity: Insensitive means log lines must match the filter, case insensitive. This means that "error" will match "error", "ERROR", "errOR", et cetera. Sensitive means that log lines must match the filter, case sensitive. This means that "error" will only match "error."
+
+Toggle match type: Exact means log lines must exactly match filter criteria. Inverse means that log lines must not match filter criteria. 
+
+**Expanding filtered lines:**
+
+When a filter is applied, unmatching lines are collapsed and are represented by a row that indicates the number of lines skipped. A collapsed row consists of two buttons: one to expand all collapsed lines between filtered lines, and one to expand 5 lines above and 5 below. If there are fewer than five lines to expand, the second button is grayed out. Expanded lines appear in the side panel, and can be re-collapsed by clicking the X icon on the left of each entry. 
+
+![exp row example](https://user-images.githubusercontent.com/624531/207634909-a8419e09-6a47-4e8d-a32a-75fdbd0a0bdc.png)
+
+You can hide the skipped line indicators entirely by toggling the expandable row option off in the details menu. 
+
+![exp rows](https://user-images.githubusercontent.com/624531/207634972-19ac3628-280f-47b8-ab65-8f7ba4d6c545.png)
+
+![exp row off](https://user-images.githubusercontent.com/624531/207634975-d9a240ac-624e-4fbf-81f7-81094f6e5ab9.png)
+
+![exp row on](https://user-images.githubusercontent.com/624531/207634978-d245ca06-5e5b-410b-9b62-4500b7491c54.png)
+
+Multiple filters can be applied at the same time. Each filter’s settings can be managed individually as described in previous sections. 
+
+![two filters](https://user-images.githubusercontent.com/624531/207635077-16f535fc-b968-4467-b6ad-f96b15ba78f9.png)
+
+You can change the filtering logic from AND and OR using the toggle in the details menu. Filtering logic will affect how multiple filters are processed.
+
+![filter logic](https://user-images.githubusercontent.com/624531/207635120-79d1daa5-e637-46e2-bd76-720ea0047e4f.png)


### PR DESCRIPTION
Now that we are using ADRs in docs/decisions, unifying all docs in the docs/ directory makes them easier to see, both in the repo and in docusaurus.
