### PR TITLE
EVG-19204 Prevent line numbers from being copied to the clipboard

### DIFF
--- a/src/components/LogRow/AnsiiRow/__snapshots__/AnsiiRow.stories.storyshot
+++ b/src/components/LogRow/AnsiiRow/__snapshots__/AnsiiRow.stories.storyshot
@@ -65,10 +65,8 @@ exports[`storyshots Storyshots components/LogRow/AnsiiRow Single Line 1`] = `
       />
     </svg>
     <pre
-      class="css-1dzaw1s"
-    >
-      0
-    </pre>
+      class="css-ei4g1d"
+    />
     <pre
       class="css-lponur"
     >

--- a/src/components/LogRow/BaseRow/Row.test.tsx
+++ b/src/components/LogRow/BaseRow/Row.test.tsx
@@ -63,6 +63,17 @@ describe("row", () => {
     await userEvent.dblClick(screen.getByText(testLog));
     expect(history.location.search).toBe("?bookmarks=0&shareLine=0");
   });
+
+  it("should not copy line numbers to clipboard", async () => {
+    const user = userEvent.setup({ writeToClipboard: true });
+
+    renderWithRouterMatch(<Row {...rowProps}>{testLog}</Row>);
+    expect(screen.getByText(/.+/).textContent).toBe("Test Log");
+    // select all of the text
+    await user.tripleClick(screen.getByText(/.+/));
+    const dataTransfer = await user.copy();
+    expect(dataTransfer?.getData("text")).toBe("Test Log");
+  });
   describe("search", () => {
     it("a search term highlights the matching text", () => {
       const regexp = /Test/i;

--- a/src/components/LogRow/BaseRow/index.tsx
+++ b/src/components/LogRow/BaseRow/index.tsx
@@ -123,7 +123,7 @@ const BaseRow = forwardRef<any, BaseRowProps>((props, ref) => {
         onClick={handleClick}
         size="small"
       />
-      <Index>{lineNumber}</Index>
+      <Index lineNumber={lineNumber} />
       <StyledPre shouldWrap={wrap}>
         <ProcessedBaseRow
           color={resmokeRowColor}
@@ -223,7 +223,7 @@ const StyledIcon = styled(Icon)`
   flex-shrink: 0;
 `;
 
-const Index = styled.pre`
+const Index = styled.pre<{ lineNumber: number }>`
   width: ${size.xl};
   margin-top: 0;
   margin-bottom: 0;
@@ -235,6 +235,10 @@ const Index = styled.pre`
   line-height: inherit;
   font-size: inherit;
   user-select: none;
+
+  ::before {
+    ${({ lineNumber }) => lineNumber && `content: "${lineNumber}";`}
+  }
 `;
 
 const StyledPre = styled.pre<{

--- a/src/components/LogRow/ResmokeRow/__snapshots__/ResmokeRow.stories.storyshot
+++ b/src/components/LogRow/ResmokeRow/__snapshots__/ResmokeRow.stories.storyshot
@@ -65,10 +65,8 @@ exports[`storyshots Storyshots components/LogRow/ResmokeRow Single Line 1`] = `
       />
     </svg>
     <pre
-      class="css-1dzaw1s"
-    >
-      8
-    </pre>
+      class="css-1imicns"
+    />
     <pre
       class="css-lponur"
     >


### PR DESCRIPTION
EVG-19204

### Description 
When trying to copy multiple lines the line numbers would be copied onto the clipboard despite them not being selected.



### Testing 
Attempted to copy multiple lines in both chrome and safari and did not see line numbers logged.
Also wrote unit tests

