### PR TITLE
EVG-18898 upgrade tests to 6.0

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -338,7 +338,7 @@ functions:
       params:
         env:
           gobin: ${goroot}/bin/go
-          MONGODB_URL: ${mongodb_url_50}
+          MONGODB_URL: ${mongodb_url_60}
           DECOMPRESS: ${decompress}
         working_dir: parsley/evergreen
         command: make get-mongodb
@@ -479,7 +479,7 @@ buildvariants:
   - name: ubuntu2004-small
     display_name: Ubuntu 20.04 (small)
     expansions:
-      mongodb_url_50: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.14.tgz
+      mongodb_url_60: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-6.0.5.tgz
       node_version: 16.17.0
     run_on:
     - ubuntu2004-small
@@ -498,7 +498,7 @@ buildvariants:
   - name: ubuntu2004-large
     display_name: Ubuntu 20.04 (large)
     expansions:
-      mongodb_url_50: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.14.tgz
+      mongodb_url_60: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-6.0.5.tgz
       node_version: 16.17.0
     run_on:
     - ubuntu2004-large


### PR DESCRIPTION
[EVG-18898](https://jira.mongodb.org/browse/EVG-18898)

### Description 
Upgrading all the tests to 6.0 to validate it in preparation for upping the version in staging/prod.
I'm not clear why there's a `mongodb_url_<version>` expansion and another `mongodb_url` expansion in the project that resolves to 4.2, but I went with it.

### Screenshots
N/A

### Testing 
Let's see if the tests pass on this PR.

### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/6340
