### PR TITLE
EVG-19166: Add linting for GraphQL files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -204,5 +204,16 @@ module.exports = {
         project: "cypress/tsconfig.json",
       },
     },
+    // For GraphQL files.
+    {
+      files: ["src/**/*.graphql"],
+      extends: "plugin:@graphql-eslint/operations-recommended",
+      rules: {
+        "@graphql-eslint/alphabetize": [
+          ERROR,
+          { selections: ["OperationDefinition"] },
+        ],
+      },
+    },
   ],
 };

--- a/.graphqlrc
+++ b/.graphqlrc
@@ -1,0 +1,2 @@
+schema: "sdlschema/**/*.graphql"
+documents: "src/gql/**/*.graphql"

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,5 +2,6 @@ module.exports = {
   "(?!src/)*.{js,ts,tsx}": ["yarn eslint:staged", "yarn prettier"], // For files that are not in src/, run eslint and prettier
   "src/**/*.{js,ts,tsx}": ["yarn eslint:staged", "yarn prettier"], // For files in src/, run eslint and prettier
   "cypress/**/*.{js,ts}": ["yarn eslint:staged", "yarn prettier"], // For files in cypress/, run eslint and prettier
+  "src/**/*.{graphql}": "yarn prettier --parser graphql", // For GraphQL files, run prettier
   "*.{ts,tsx}": () => "yarn check-types", // For TypeScript files, check types
 };

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@graphql-codegen/cli": "3.2.2",
     "@graphql-codegen/typescript": "3.0.2",
     "@graphql-codegen/typescript-operations": "3.0.2",
+    "@graphql-eslint/eslint-plugin": "3.18.0",
     "@storybook/addon-actions": "7.0.0-beta.34",
     "@storybook/addon-essentials": "7.0.0-beta.34",
     "@storybook/addon-interactions": "7.0.0-beta.38",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,6 +2167,23 @@
     parse-filepath "^1.0.2"
     tslib "~2.5.0"
 
+"@graphql-eslint/eslint-plugin@3.18.0":
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/@graphql-eslint/eslint-plugin/-/eslint-plugin-3.18.0.tgz#071b5580d1d47ac0f25fd4296fea4105ddd8e401"
+  integrity sha512-riEEfRycc0+pWxcEWqHi8woRxzg1xZqAfh9DRACJUR7bTN8dmc1N04i7+pvW4sevClUFYC2wuL1Vtr+DwzXLUg==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@graphql-tools/code-file-loader" "^7.3.6"
+    "@graphql-tools/graphql-tag-pluck" "^7.3.6"
+    "@graphql-tools/utils" "^9.0.0"
+    chalk "^4.1.2"
+    debug "^4.3.4"
+    fast-glob "^3.2.12"
+    graphql-config "^4.4.0"
+    graphql-depth-limit "^1.1.0"
+    lodash.lowercase "^4.3.0"
+    tslib "^2.4.1"
+
 "@graphql-tools/apollo-engine-loader@^7.3.6":
   version "7.3.26"
   resolved "https://registry.yarnpkg.com/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-7.3.26.tgz#91e54460d5579933e42a2010b8688c3459c245d8"
@@ -2187,7 +2204,7 @@
     tslib "^2.4.0"
     value-or-promise "1.0.12"
 
-"@graphql-tools/code-file-loader@^7.3.17":
+"@graphql-tools/code-file-loader@^7.3.17", "@graphql-tools/code-file-loader@^7.3.6":
   version "7.3.21"
   resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-7.3.21.tgz#3eed4ff4610cf0a6f4b1be17d0bce1eec9359479"
   integrity sha512-dj+OLnz1b8SYkXcuiy0CUQ25DWnOEyandDlOcdBqU3WVwh5EEVbn0oXUYm90fDlq2/uut00OrtC5Wpyhi3tAvA==
@@ -2294,7 +2311,7 @@
     tslib "^2.4.0"
     unixify "^1.0.0"
 
-"@graphql-tools/graphql-tag-pluck@7.5.0", "@graphql-tools/graphql-tag-pluck@^7.4.6":
+"@graphql-tools/graphql-tag-pluck@7.5.0", "@graphql-tools/graphql-tag-pluck@^7.3.6", "@graphql-tools/graphql-tag-pluck@^7.4.6":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.5.0.tgz#be99bc6b5e8331a2379ab4585d71b057eb981497"
   integrity sha512-76SYzhSlH50ZWkhWH6OI94qrxa8Ww1ZeOU04MdtpSeQZVT2rjGWeTb3xM3kjTVWQJsr/YJBhDeNPGlwNUWfX4Q==
@@ -5410,6 +5427,11 @@ array.prototype.tosorted@^1.1.1:
     es-shim-unscopables "^1.0.0"
     get-intrinsic "^1.1.3"
 
+arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+  integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
+
 asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -7812,6 +7834,17 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
+fast-glob@^3.2.12:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-glob@^3.2.7, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
@@ -8397,7 +8430,7 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
-graphql-config@^4.5.0:
+graphql-config@^4.4.0, graphql-config@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-4.5.0.tgz#257c2338950b8dce295a27f75c5f6c39f8f777b2"
   integrity sha512-x6D0/cftpLUJ0Ch1e5sj1TZn6Wcxx4oMfmhaG9shM0DKajA9iR+j1z86GSTQ19fShbGvrSSvbIQsHku6aQ6BBw==
@@ -8413,6 +8446,13 @@ graphql-config@^4.5.0:
     minimatch "4.2.3"
     string-env-interpolation "1.0.1"
     tslib "^2.4.0"
+
+graphql-depth-limit@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz#59fe6b2acea0ab30ee7344f4c75df39cc18244e8"
+  integrity sha512-+3B2BaG8qQ8E18kzk9yiSdAa75i/hnnOwgSeAxVJctGQPvmeiLtqKOYF6HETCyRjiF7Xfsyal0HbLlxCQkgkrw==
+  dependencies:
+    arrify "^1.0.1"
 
 graphql-request@^5.0.0:
   version "5.2.0"
@@ -10306,6 +10346,11 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
+
+lodash.lowercase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.lowercase/-/lodash.lowercase-4.3.0.tgz#46515aced4acb0b7093133333af068e4c3b14e9d"
+  integrity sha512-UcvP1IZYyDKyEL64mmrwoA1AbFu5ahojhTtkOUr1K9dbuxzS9ev8i4TxMMGCqRC9TE8uDaSoufNAXxRPNTseVA==
 
 lodash.memoize@4.x:
   version "4.1.2"


### PR DESCRIPTION
EVG-19166

### Description 
This PR adds linting for GraphQL files in Parsley. To get this to work you will need to add `"graphql"` to your VSCode settings for `eslint.validate` but be warned that this will break on Spruce because I'm pretty sure the ESLint settings are wrong on Spruce. 🧍

### Screenshots
(Linting on top of Sophie's PR)

https://user-images.githubusercontent.com/47064971/229211377-d36f550d-090e-4010-9f77-ac8f3b87478d.mov



### Testing 
<img width="100" alt="Screenshot 2023-03-31 at 3 02 23 PM" src="https://user-images.githubusercontent.com/47064971/229207316-c4501791-6984-430e-8e38-368ab1d8f255.png">