### PR TITLE
EVG-19304 Memoize useQueryParams return value

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1107,6 +1107,7 @@ export type PodEventLogData = {
   newStatus?: Maybe<Scalars["String"]>;
   oldStatus?: Maybe<Scalars["String"]>;
   reason?: Maybe<Scalars["String"]>;
+  task?: Maybe<Task>;
   taskExecution?: Maybe<Scalars["Int"]>;
   taskID?: Maybe<Scalars["String"]>;
   taskStatus?: Maybe<Scalars["String"]>;

--- a/src/hooks/useQueryParam/index.ts
+++ b/src/hooks/useQueryParam/index.ts
@@ -13,7 +13,9 @@ const useQueryParams = (parseOptions?: ParseOptions) => {
   const navigate = useNavigate();
   const setQueryString = useCallback(
     (params: { [key: string]: any }) => {
-      const stringifiedQuery = stringifyQuery(params);
+      const stringifiedQuery = stringifyQuery(params, {
+        skipEmptyString: false,
+      });
       navigate(`?${stringifiedQuery}`, { replace: true });
     },
     [navigate]

--- a/src/hooks/useQueryParam/index.ts
+++ b/src/hooks/useQueryParam/index.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { ParseOptions } from "query-string";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { conditionalCastToArray } from "utils/array";
@@ -19,10 +19,11 @@ const useQueryParams = (parseOptions?: ParseOptions) => {
     [navigate]
   );
 
-  return [
-    parseQueryString(searchParams.toString(), parseOptions),
-    setQueryString,
-  ] as const;
+  const searchParamsObject = useMemo(
+    () => parseQueryString(searchParams.toString(), parseOptions),
+    [searchParams, parseOptions]
+  );
+  return [searchParamsObject, setQueryString] as const;
 };
 
 /**

--- a/src/utils/query-string/index.ts
+++ b/src/utils/query-string/index.ts
@@ -1,4 +1,4 @@
-import { ParseOptions, parse, stringify } from "query-string";
+import { ParseOptions, StringifyOptions, parse, stringify } from "query-string";
 import { CaseSensitivity, MatchType } from "constants/enums";
 import { Filters } from "types/logs";
 
@@ -15,11 +15,15 @@ export const parseQueryString = (
   return parse(search, parseOptions);
 };
 
-export const stringifyQuery = (object: { [key: string]: any }) =>
+export const stringifyQuery = (
+  object: { [key: string]: any },
+  options: StringifyOptions = {}
+) =>
   stringify(object, {
     arrayFormat: "comma",
     skipNull: true,
     skipEmptyString: true,
+    ...options,
   });
 
 export const parseFilters = (filters: string[]): Filters => {

--- a/src/utils/query-string/query-string.test.ts
+++ b/src/utils/query-string/query-string.test.ts
@@ -129,6 +129,15 @@ describe("query-string", () => {
     it("ignores emptyStrings", () => {
       expect(stringifyQuery({ a: "hello", b: "" })).toBe("a=hello");
     });
+    it("should preserve empty strings if skipEmptyString is passed in", () => {
+      let result = stringifyQuery(
+        { foo: "", bar: null },
+        { skipEmptyString: false }
+      );
+      expect(result).toBe("foo=");
+      result = stringifyQuery({ foo: "", bar: 21 }, { skipEmptyString: false });
+      expect(result).toBe("bar=21&foo=");
+    });
     it("can handle empty input", () => {
       expect(stringifyQuery({})).toBe("");
     });


### PR DESCRIPTION
EVG-19304

### Description 
Eliminates a render caused by `parseQueryString(searchParams.toString())` returning a new reference each time.
Incorporates changes to stringifyQuery introduced in https://github.com/evergreen-ci/spruce/pull/1766
