### PR TITLE
EVG-19318 Memoize analytics hooks

### DIFF
--- a/src/analytics/addPageAction.ts
+++ b/src/analytics/addPageAction.ts
@@ -4,7 +4,7 @@ export interface Analytics<Action> {
   sendEvent: (action: Action) => void;
 }
 
-type AnalyticsObject =
+export type AnalyticsObject =
   | "LogDrop"
   | "LogWindow"
   | "Preferences"
@@ -14,7 +14,7 @@ type AnalyticsObject =
 interface RequiredProperties {
   object: AnalyticsObject;
 }
-interface ActionType {
+export interface ActionType {
   name: string;
 }
 

--- a/src/analytics/loadingPage/useLogDownloadAnalytics.ts
+++ b/src/analytics/loadingPage/useLogDownloadAnalytics.ts
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from "react";
 import {
   Analytics as A,
   Properties,
@@ -13,11 +14,11 @@ interface P extends Properties {}
 interface Analytics extends A<Action> {}
 
 export const useLogDownloadAnalytics = (): Analytics => {
-  const sendEvent: Analytics["sendEvent"] = (action) => {
+  const sendEvent: Analytics["sendEvent"] = useCallback((action) => {
     addPageAction<Action, P>(action, {
       object: "LoadingPage",
     });
-  };
+  }, []);
 
-  return { sendEvent };
+  return useMemo(() => ({ sendEvent }), [sendEvent]);
 };

--- a/src/analytics/logDrop/useLogDropAnalytics.ts
+++ b/src/analytics/logDrop/useLogDropAnalytics.ts
@@ -1,9 +1,4 @@
-import { useCallback, useMemo } from "react";
-import {
-  Analytics as A,
-  Properties,
-  addPageAction,
-} from "analytics/addPageAction";
+import { useAnalyticsRoot } from "analytics/useAnalyticsRoot";
 import { LogTypes } from "constants/enums";
 
 type Action =
@@ -12,15 +7,4 @@ type Action =
   | { name: "Uploaded Log File With Picker" }
   | { name: "Processed Log"; logType: LogTypes };
 
-interface P extends Properties {}
-interface Analytics extends A<Action> {}
-
-export const useLogDropAnalytics = (): Analytics => {
-  const sendEvent: Analytics["sendEvent"] = useCallback((action) => {
-    addPageAction<Action, P>(action, {
-      object: "LogDrop",
-    });
-  }, []);
-
-  return useMemo(() => ({ sendEvent }), []);
-};
+export const useLogDropAnalytics = () => useAnalyticsRoot<Action>("LogDrop");

--- a/src/analytics/logDrop/useLogDropAnalytics.ts
+++ b/src/analytics/logDrop/useLogDropAnalytics.ts
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from "react";
 import {
   Analytics as A,
   Properties,
@@ -15,11 +16,11 @@ interface P extends Properties {}
 interface Analytics extends A<Action> {}
 
 export const useLogDropAnalytics = (): Analytics => {
-  const sendEvent: Analytics["sendEvent"] = (action) => {
+  const sendEvent: Analytics["sendEvent"] = useCallback((action) => {
     addPageAction<Action, P>(action, {
       object: "LogDrop",
     });
-  };
+  }, []);
 
-  return { sendEvent };
+  return useMemo(() => ({ sendEvent }), []);
 };

--- a/src/analytics/logWindow/useLogWindowAnalytics.ts
+++ b/src/analytics/logWindow/useLogWindowAnalytics.ts
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from "react";
 import {
   Analytics as A,
   Properties,
@@ -26,11 +27,11 @@ interface P extends Properties {}
 interface Analytics extends A<Action> {}
 
 export const useLogWindowAnalytics = (): Analytics => {
-  const sendEvent: Analytics["sendEvent"] = (action) => {
+  const sendEvent: Analytics["sendEvent"] = useCallback((action) => {
     addPageAction<Action, P>(action, {
       object: "LogWindow",
     });
-  };
+  }, []);
 
-  return { sendEvent };
+  return useMemo(() => ({ sendEvent }), [sendEvent]);
 };

--- a/src/analytics/logWindow/useLogWindowAnalytics.ts
+++ b/src/analytics/logWindow/useLogWindowAnalytics.ts
@@ -1,9 +1,4 @@
-import { useCallback, useMemo } from "react";
-import {
-  Analytics as A,
-  Properties,
-  addPageAction,
-} from "analytics/addPageAction";
+import { useAnalyticsRoot } from "analytics/useAnalyticsRoot";
 import { DIRECTION } from "context/LogContext/types";
 import { Filter } from "types/logs";
 
@@ -23,15 +18,5 @@ type Action =
   | { name: "Collapsed Lines" }
   | { name: "Paginated Through Search Results"; direction: DIRECTION };
 
-interface P extends Properties {}
-interface Analytics extends A<Action> {}
-
-export const useLogWindowAnalytics = (): Analytics => {
-  const sendEvent: Analytics["sendEvent"] = useCallback((action) => {
-    addPageAction<Action, P>(action, {
-      object: "LogWindow",
-    });
-  }, []);
-
-  return useMemo(() => ({ sendEvent }), [sendEvent]);
-};
+export const useLogWindowAnalytics = () =>
+  useAnalyticsRoot<Action>("LogWindow");

--- a/src/analytics/preferences/usePreferencesAnalytics.ts
+++ b/src/analytics/preferences/usePreferencesAnalytics.ts
@@ -1,9 +1,4 @@
-import { useCallback, useMemo } from "react";
-import {
-  Analytics as A,
-  Properties,
-  addPageAction,
-} from "analytics/addPageAction";
+import { useAnalyticsRoot } from "analytics/useAnalyticsRoot";
 import { FilterLogic } from "constants/enums";
 
 type Action =
@@ -20,15 +15,5 @@ type Action =
   | { name: "Toggled Filter Logic"; logic: FilterLogic }
   | { name: "Toggled Expandable Rows"; on: boolean };
 
-interface P extends Properties {}
-interface Analytics extends A<Action> {}
-
-export const usePreferencesAnalytics = (): Analytics => {
-  const sendEvent: Analytics["sendEvent"] = useCallback((action) => {
-    addPageAction<Action, P>(action, {
-      object: "Preferences",
-    });
-  }, []);
-
-  return useMemo(() => ({ sendEvent }), [sendEvent]);
-};
+export const usePreferencesAnalytics = () =>
+  useAnalyticsRoot<Action>("Preferences");

--- a/src/analytics/preferences/usePreferencesAnalytics.ts
+++ b/src/analytics/preferences/usePreferencesAnalytics.ts
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from "react";
 import {
   Analytics as A,
   Properties,
@@ -23,11 +24,11 @@ interface P extends Properties {}
 interface Analytics extends A<Action> {}
 
 export const usePreferencesAnalytics = (): Analytics => {
-  const sendEvent: Analytics["sendEvent"] = (action) => {
+  const sendEvent: Analytics["sendEvent"] = useCallback((action) => {
     addPageAction<Action, P>(action, {
       object: "Preferences",
     });
-  };
+  }, []);
 
-  return { sendEvent };
+  return useMemo(() => ({ sendEvent }), [sendEvent]);
 };

--- a/src/analytics/shortcuts/useShortcutAnalytics.ts
+++ b/src/analytics/shortcuts/useShortcutAnalytics.ts
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from "react";
 import {
   Analytics as A,
   Properties,
@@ -10,11 +11,11 @@ interface P extends Properties {}
 interface Analytics extends A<Action> {}
 
 export const useShortcutAnalytics = (): Analytics => {
-  const sendEvent: Analytics["sendEvent"] = (action) => {
+  const sendEvent: Analytics["sendEvent"] = useCallback((action) => {
     addPageAction<Action, P>(action, {
       object: "Shortcut",
     });
-  };
+  }, []);
 
-  return { sendEvent };
+  return useMemo(() => ({ sendEvent }), [sendEvent]);
 };

--- a/src/analytics/shortcuts/useShortcutAnalytics.ts
+++ b/src/analytics/shortcuts/useShortcutAnalytics.ts
@@ -1,21 +1,5 @@
-import { useCallback, useMemo } from "react";
-import {
-  Analytics as A,
-  Properties,
-  addPageAction,
-} from "analytics/addPageAction";
+import { useAnalyticsRoot } from "analytics/useAnalyticsRoot";
 
 type Action = { name: "Used Shortcut"; keys: string };
 
-interface P extends Properties {}
-interface Analytics extends A<Action> {}
-
-export const useShortcutAnalytics = (): Analytics => {
-  const sendEvent: Analytics["sendEvent"] = useCallback((action) => {
-    addPageAction<Action, P>(action, {
-      object: "Shortcut",
-    });
-  }, []);
-
-  return useMemo(() => ({ sendEvent }), [sendEvent]);
-};
+export const useShortcutAnalytics = () => useAnalyticsRoot<Action>("Shortcut");

--- a/src/analytics/useAnalyticsRoot.ts
+++ b/src/analytics/useAnalyticsRoot.ts
@@ -1,0 +1,23 @@
+import { useCallback, useMemo } from "react";
+import {
+  ActionType,
+  Analytics,
+  AnalyticsObject,
+  Properties,
+  addPageAction,
+} from "analytics/addPageAction";
+
+interface P extends Properties {}
+
+export const useAnalyticsRoot = <Action extends ActionType>(
+  object: AnalyticsObject
+): Analytics<Action> => {
+  const sendEvent: Analytics<Action>["sendEvent"] = useCallback(
+    (action) => {
+      addPageAction<Action, P>(action, { object });
+    },
+    [object]
+  );
+
+  return useMemo(() => ({ sendEvent }), [sendEvent]);
+};


### PR DESCRIPTION
EVG-19318

### Description 
While working on #233 I noticed that components were rerendering due to `sendEvent` being initialized on each render. Added some memoization to the analytics hooks to prevent these rerenders. This eliminates one render 

Waiting on #249 


