### PR TITLE
EVG-18990 Override Home and End button functionality in Paginated view

### DIFF
--- a/cypress/integration/ansiiLogs/ansii_logView.ts
+++ b/cypress/integration/ansiiLogs/ansii_logView.ts
@@ -127,7 +127,7 @@ describe("Jump to line", () => {
 
   it("should be able to use the bookmarks bar to jump to a line when there are no collapsed rows", () => {
     cy.visit(`${logLink}?bookmarks=0,297`);
-    cy.dataCy("log-row-4").dblclick({ force: true });
+    cy.dataCy("log-row-4").should("be.visible").dblclick({ force: true });
     cy.dataCy("bookmark-4").should("be.visible");
 
     cy.dataCy("bookmark-297").click();

--- a/cypress/integration/resmokeLogs/resmoke_logView.ts
+++ b/cypress/integration/resmokeLogs/resmoke_logView.ts
@@ -172,7 +172,7 @@ describe("Jump to line", () => {
 
   it("should be able to use the bookmarks bar to jump to a line when there are no collapsed rows", () => {
     cy.visit(`${logLink}?bookmarks=0,11079`);
-    cy.dataCy("log-row-4").dblclick({ force: true });
+    cy.dataCy("log-row-4").should("be.visible").dblclick({ force: true });
     cy.dataCy("bookmark-4").should("be.visible");
 
     cy.dataCy("bookmark-11079").click();
@@ -185,7 +185,7 @@ describe("Jump to line", () => {
 
   it("should be able to use the bookmarks bar to jump to a line when there are collapsed rows", () => {
     cy.visit(`${logLink}?bookmarks=0,11079&filters=100repl_hb`);
-    cy.dataCy("log-row-30").dblclick({ force: true });
+    cy.dataCy("log-row-30").should("be.visible").dblclick({ force: true });
 
     cy.dataCy("bookmark-11079").click();
     cy.dataCy("log-row-11079").should("be.visible");

--- a/src/components/LogPane/index.tsx
+++ b/src/components/LogPane/index.tsx
@@ -1,9 +1,7 @@
 import { useEffect } from "react";
 import PaginatedVirtualList from "components/PaginatedVirtualList";
-import { CharKey } from "constants/keys";
 import { QueryParams } from "constants/queryParams";
 import { useLogContext } from "context/LogContext";
-import { useKeyboardShortcut } from "hooks";
 import { useQueryParam } from "hooks/useQueryParam";
 import { leaveBreadcrumb } from "utils/errorReporting";
 import { findLineIndex } from "utils/findLineIndex";
@@ -13,21 +11,12 @@ interface LogPaneProps {
   rowCount: number;
 }
 const LogPane: React.FC<LogPaneProps> = ({ rowRenderer, rowCount }) => {
-  const { processedLogLines, scrollToLine, listRef, lineCount } =
-    useLogContext();
+  const { processedLogLines, scrollToLine, listRef } = useLogContext();
 
   const [shareLine] = useQueryParam<number | undefined>(
     QueryParams.ShareLine,
     undefined
   );
-
-  useKeyboardShortcut({ charKey: CharKey.PageEnd }, () => {
-    scrollToLine(lineCount - 1);
-  });
-
-  useKeyboardShortcut({ charKey: CharKey.PageHome }, () => {
-    scrollToLine(0);
-  });
 
   useEffect(() => {
     const initialScrollIndex = findLineIndex(processedLogLines, shareLine);

--- a/src/components/LogPane/index.tsx
+++ b/src/components/LogPane/index.tsx
@@ -49,7 +49,7 @@ const LogPane: React.FC<LogPaneProps> = ({ rowRenderer, rowCount }) => {
     <PaginatedVirtualList
       ref={listRef}
       paginationOffset={50}
-      paginationThreshold={50000}
+      paginationThreshold={500000}
       rowCount={rowCount}
       rowRenderer={rowRenderer}
     />

--- a/src/components/LogPane/index.tsx
+++ b/src/components/LogPane/index.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from "react";
 import PaginatedVirtualList from "components/PaginatedVirtualList";
+import { CharKey } from "constants/keys";
 import { QueryParams } from "constants/queryParams";
 import { useLogContext } from "context/LogContext";
+import { useKeyboardShortcut } from "hooks";
 import { useQueryParam } from "hooks/useQueryParam";
 import { leaveBreadcrumb } from "utils/errorReporting";
 import { findLineIndex } from "utils/findLineIndex";
@@ -11,12 +13,21 @@ interface LogPaneProps {
   rowCount: number;
 }
 const LogPane: React.FC<LogPaneProps> = ({ rowRenderer, rowCount }) => {
-  const { processedLogLines, scrollToLine, listRef } = useLogContext();
+  const { processedLogLines, scrollToLine, listRef, lineCount } =
+    useLogContext();
 
   const [shareLine] = useQueryParam<number | undefined>(
     QueryParams.ShareLine,
     undefined
   );
+
+  useKeyboardShortcut({ charKey: CharKey.PageEnd }, () => {
+    scrollToLine(lineCount - 1);
+  });
+
+  useKeyboardShortcut({ charKey: CharKey.PageHome }, () => {
+    scrollToLine(0);
+  });
 
   useEffect(() => {
     const initialScrollIndex = findLineIndex(processedLogLines, shareLine);
@@ -38,7 +49,7 @@ const LogPane: React.FC<LogPaneProps> = ({ rowRenderer, rowCount }) => {
     <PaginatedVirtualList
       ref={listRef}
       paginationOffset={50}
-      paginationThreshold={500000}
+      paginationThreshold={50000}
       rowCount={rowCount}
       rowRenderer={rowRenderer}
     />

--- a/src/components/PaginatedVirtualList/index.tsx
+++ b/src/components/PaginatedVirtualList/index.tsx
@@ -1,5 +1,7 @@
 import { forwardRef, useCallback, useEffect, useRef } from "react";
 import { ItemContent, Virtuoso, VirtuosoHandle } from "react-virtuoso";
+import { CharKey } from "constants/keys";
+import { useKeyboardShortcut } from "hooks";
 import { PaginatedVirtualListRef } from "./types";
 import usePaginatedVirtualList from "./usePaginatedVirtualList";
 
@@ -48,6 +50,14 @@ const PaginatedVirtualList = forwardRef<
       paginationThreshold,
       paginationOffset,
       ref: listRef,
+    });
+
+    useKeyboardShortcut({ charKey: CharKey.PageEnd }, () => {
+      scrollToLine(rowCount - 1);
+    });
+
+    useKeyboardShortcut({ charKey: CharKey.PageHome }, () => {
+      scrollToLine(0);
     });
 
     // itemContent maps the paginated index to the actual index in the list

--- a/src/constants/keys.ts
+++ b/src/constants/keys.ts
@@ -38,6 +38,8 @@ enum CharKey {
   ArrowLeft = "ArrowLeft",
   ArrowRight = "ArrowRight",
   ArrowUp = "ArrowUp",
+  PageEnd = "End",
+  PageHome = "Home",
   ForwardSlash = "/",
   Period = ".",
   Comma = ",",


### PR DESCRIPTION
EVG-18990

### Description 
Since we are using a paginated list for the log view using the Home and End button would not take you to the top and bottom of the list. This PR overrides the default behavior and uses the scrollToLine function to jump automatically to the first and last line even if the view is paginated. 
### Screenshots


Before:
https://user-images.githubusercontent.com/4605522/230675781-b80dfba5-03fd-437c-8422-ce9ddfe6ad29.mov

After:
https://user-images.githubusercontent.com/4605522/230675772-eec8340f-bfce-4f8e-86df-b9477109655a.mov

### Testing 
Lower paginationThreshold and use Home and End button to jump to parts of the log