### PR TITLE
EVG-19608: Trim task names

### DIFF
--- a/src/components/SubHeader/EvergreenTaskSubHeader.tsx
+++ b/src/components/SubHeader/EvergreenTaskSubHeader.tsx
@@ -14,7 +14,7 @@ import {
   TaskQueryVariables,
 } from "gql/generated/types";
 import { GET_LOGKEEPER_TASK, GET_TASK } from "gql/queries";
-import { shortenGithash } from "utils/string";
+import { shortenGithash, trimStringFromMiddle } from "utils/string";
 
 interface Props {
   buildID: string;
@@ -95,10 +95,12 @@ export const EvergreenTaskSubHeader: React.FC<Props> = ({
       href: getEvergreenTaskURL(taskID, taskExecution),
       text: (
         <>
-          {displayName} <TaskStatusBadge status={status} />
+          {trimStringFromMiddle(displayName, 30)}{" "}
+          <TaskStatusBadge status={status} />
         </>
       ),
       "data-cy": "task-breadcrumb",
+      tooltipText: displayName.length > 30 && displayName,
       onClick: () => {
         sendEvent({ name: "Opened Task Link" });
       },


### PR DESCRIPTION
EVG-19608

### Description 
<!-- Add description, context, thought process, etc -->
- Trim task names and show tooltip to prevent overflow. Since the task breadcrumb includes a badge, the trimming is handled outside of the breadcrumb component

### Screenshots
<!-- Add screenshots of visible changes -->
<img width="877" alt="image" src="https://user-images.githubusercontent.com/9298431/231871071-91d43258-0436-45f1-92c1-ad203b1f502b.png">

### Testing 
<!-- Add a description of how you tested it -->
- View a trimmed task using `yarn prod` at http://localhost:5173/resmoke/5d885fa3b5ca3eefec3fff6e3b0e559d/test/1753d455e14b437e0d5661fee23aab85?bookmarks=0,3603&shareLine=0