### PR TITLE
EVG-19623 Limit streamed log file download size

### DIFF
--- a/src/constants/logs.ts
+++ b/src/constants/logs.ts
@@ -1,0 +1,3 @@
+const LOG_FILE_SIZE_LIMIT = 1024 * 1024 * 1024 * 2.5; // 2.5 GB
+
+export { LOG_FILE_SIZE_LIMIT };

--- a/src/hooks/useLogDownloader/index.ts
+++ b/src/hooks/useLogDownloader/index.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useLogDownloadAnalytics } from "analytics";
 import { LogTypes } from "constants/enums";
 import { LOG_FILE_SIZE_LIMIT } from "constants/logs";
+import { useToastContext } from "context/toast";
 import useStateRef from "hooks/useStateRef";
 import { isProduction } from "utils/environmentVariables";
 import { leaveBreadcrumb, reportError } from "utils/errorReporting";
@@ -28,6 +29,8 @@ const useLogDownloader = (
   const [fileSize, setFileSize, getFileSize] = useStateRef<number>(0);
   const [isLoading, setIsLoading] = useState(true);
   const { sendEvent } = useLogDownloadAnalytics();
+  const dispatchToast = useToastContext();
+
   useEffect(() => {
     leaveBreadcrumb("useLogDownloader", { url }, "request");
     const abortController = new AbortController();
@@ -46,7 +49,13 @@ const useLogDownloader = (
           { incompleteDownloadError, reason },
           "error"
         );
-        setError(reason);
+        dispatchToast.warning(
+          "We were only able to partially download this log. Use the Evergreen CLI command in the details menu to download the log on to your machine.",
+          true,
+          {
+            title: "Log not fully downloaded",
+          }
+        );
       },
     })
       .then((logs) => {

--- a/src/hooks/useLogDownloader/index.ts
+++ b/src/hooks/useLogDownloader/index.ts
@@ -50,7 +50,7 @@ const useLogDownloader = (
           "error"
         );
         dispatchToast.warning(
-          "We were only able to partially download this log. Use the Evergreen CLI command in the details menu to download the log on to your machine.",
+          "Parsley was only able to partially download this log. Use the Evergreen CLI command in the details menu to download the log onto your machine.",
           true,
           {
             title: "Log not fully downloaded",

--- a/src/hooks/useLogDownloader/useLogDownloader.test.ts
+++ b/src/hooks/useLogDownloader/useLogDownloader.test.ts
@@ -117,7 +117,7 @@ describe("useLogDownloader", () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.data).toStrictEqual(["chunk1"]);
     expect(dispatchToast.warning).toHaveBeenCalledWith(
-      "We were only able to partially download this log. Use the Evergreen CLI command in the details menu to download the log on to your machine.",
+      "Parsley was only able to partially download this log. Use the Evergreen CLI command in the details menu to download the log onto your machine.",
       true,
       { title: "Log not fully downloaded" }
     );

--- a/src/hooks/useLogDownloader/useLogDownloader.test.ts
+++ b/src/hooks/useLogDownloader/useLogDownloader.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react-hooks";
 import { LogTypes } from "constants/enums";
+import { RenderFakeToastContext } from "context/toast/__mocks__";
 import { useLogDownloader } from ".";
 
 const API_URL = "/some/endpoint";
@@ -27,6 +28,8 @@ describe("useLogDownloader", () => {
 
     mockFetch.mockResolvedValue(response);
 
+    // RenderFakeToastContext is a mock of the ToastContext
+    RenderFakeToastContext();
     const { result, waitForNextUpdate } = renderHook(() =>
       useLogDownloader(API_URL, LogTypes.RESMOKE_LOGS)
     );
@@ -45,6 +48,8 @@ describe("useLogDownloader", () => {
       .mockRejectedValue(new Error("Something went wrong"));
     jest.spyOn(global, "fetch").mockImplementation(mockFetchPromise);
 
+    // RenderFakeToastContext is a mock of the ToastContext
+    RenderFakeToastContext();
     const { result, waitForNextUpdate } = renderHook(() =>
       useLogDownloader(API_URL, LogTypes.EVERGREEN_TASK_LOGS)
     );
@@ -62,6 +67,8 @@ describe("useLogDownloader", () => {
 
     mockFetch.mockResolvedValue(response);
 
+    // RenderFakeToastContext is a mock of the ToastContext
+    RenderFakeToastContext();
     const { result, waitForNextUpdate } = renderHook(() =>
       useLogDownloader(API_URL, LogTypes.RESMOKE_LOGS)
     );
@@ -80,6 +87,8 @@ describe("useLogDownloader", () => {
 
     mockFetch.mockResolvedValue(response);
 
+    // RenderFakeToastContext is a mock of the ToastContext
+    RenderFakeToastContext();
     const { result, waitForNextUpdate } = renderHook(() =>
       useLogDownloader(API_URL, LogTypes.RESMOKE_LOGS)
     );
@@ -98,14 +107,20 @@ describe("useLogDownloader", () => {
 
     mockFetch.mockResolvedValue(response);
 
+    // RenderFakeToastContext is a mock of the ToastContext
+    const { dispatchToast } = RenderFakeToastContext();
     const { result, waitForNextUpdate } = renderHook(() =>
       useLogDownloader(API_URL, LogTypes.RESMOKE_LOGS, 5)
     );
     expect(result.current.isLoading).toBe(true);
     await waitForNextUpdate();
     expect(result.current.isLoading).toBe(false);
-    expect(result.current.error).toBe("FILE_TOO_LARGE");
     expect(result.current.data).toStrictEqual(["chunk1"]);
+    expect(dispatchToast.warning).toHaveBeenCalledWith(
+      "We were only able to partially download this log. Use the Evergreen CLI command in the details menu to download the log on to your machine.",
+      true,
+      { title: "Log not fully downloaded" }
+    );
   });
 });
 

--- a/src/utils/fetchLogFile/fetchLogFile.test.ts
+++ b/src/utils/fetchLogFile/fetchLogFile.test.ts
@@ -117,7 +117,7 @@ describe("fetchLogFile", () => {
       downloadSizeLimit: 4,
     });
 
-    expect(mockOnIncompleteDownload).toHaveBeenCalledWith();
+    expect(mockOnIncompleteDownload).toHaveBeenCalledWith("FILE_TOO_LARGE");
     expect(result).toStrictEqual(["Hello"]);
   });
 });

--- a/src/utils/fetchLogFile/index.ts
+++ b/src/utils/fetchLogFile/index.ts
@@ -2,8 +2,6 @@ type IncompleteDownloadReason = "SERVER_ERROR" | "FILE_TOO_LARGE";
 export type StreamedFetchOptions = {
   abortController?: AbortController;
   onProgress?: (progress: number) => void;
-  // Refactor onIncompleteDownload to require an error object if reason is SERVER_ERROR
-
   onIncompleteDownload?: (
     reason: IncompleteDownloadReason,
     error?: Error

--- a/src/utils/fetchLogFile/index.ts
+++ b/src/utils/fetchLogFile/index.ts
@@ -1,6 +1,6 @@
 enum IncompleteDownloadReason {
-  SERVER_ERROR = "SERVER_ERROR",
-  FILE_TOO_LARGE = "FILE_TOO_LARGE",
+  ServerError = "SERVER_ERROR",
+  FileTooLarge = "FILE_TOO_LARGE",
 }
 
 export type StreamedFetchOptions = {

--- a/src/utils/fetchLogFile/index.ts
+++ b/src/utils/fetchLogFile/index.ts
@@ -1,4 +1,8 @@
-type IncompleteDownloadReason = "SERVER_ERROR" | "FILE_TOO_LARGE";
+enum IncompleteDownloadReason {
+  SERVER_ERROR = "SERVER_ERROR",
+  FILE_TOO_LARGE = "FILE_TOO_LARGE",
+}
+
 export type StreamedFetchOptions = {
   abortController?: AbortController;
   onProgress?: (progress: number) => void;
@@ -48,7 +52,9 @@ const streamedFetch = async (url: string, options: StreamedFetchOptions) => {
           if (options?.downloadSizeLimit) {
             // If we've hit the file size limit, stop streaming and close the stream
             if (bytesFetched > options.downloadSizeLimit) {
-              options?.onIncompleteDownload?.("FILE_TOO_LARGE");
+              options?.onIncompleteDownload?.(
+                IncompleteDownloadReason.FILE_TOO_LARGE
+              );
               controller.close();
               break;
             }
@@ -69,7 +75,10 @@ const streamedFetch = async (url: string, options: StreamedFetchOptions) => {
         // the download was incomplete. This is because the controller will close the connection with an error if
         // we hit the timeout, we should instead return the bytes we've fetched so far.
         if (bytesFetched > 0) {
-          options?.onIncompleteDownload?.("SERVER_ERROR", error as Error);
+          options?.onIncompleteDownload?.(
+            IncompleteDownloadReason.SERVER_ERROR,
+            error as Error
+          );
           controller.close();
         } else {
           controller.error(error);

--- a/src/utils/fetchLogFile/index.ts
+++ b/src/utils/fetchLogFile/index.ts
@@ -53,7 +53,7 @@ const streamedFetch = async (url: string, options: StreamedFetchOptions) => {
             // If we've hit the file size limit, stop streaming and close the stream
             if (bytesFetched > options.downloadSizeLimit) {
               options?.onIncompleteDownload?.(
-                IncompleteDownloadReason.FILE_TOO_LARGE
+                IncompleteDownloadReason.FileTooLarge
               );
               controller.close();
               break;
@@ -76,7 +76,7 @@ const streamedFetch = async (url: string, options: StreamedFetchOptions) => {
         // we hit the timeout, we should instead return the bytes we've fetched so far.
         if (bytesFetched > 0) {
           options?.onIncompleteDownload?.(
-            IncompleteDownloadReason.SERVER_ERROR,
+            IncompleteDownloadReason.ServerError,
             error as Error
           );
           controller.close();

--- a/src/utils/fetchLogFile/index.ts
+++ b/src/utils/fetchLogFile/index.ts
@@ -66,8 +66,8 @@ const streamedFetch = async (url: string, options: StreamedFetchOptions) => {
         }
       } catch (error) {
         // If we hit an error, but we've already fetched some bytes, then we can assume that
-        // the download was incomplete. This is because the load balancer will close the connection if
-        // we hit the timeout, but we won't get an error until we try to read the next chunk.
+        // the download was incomplete. This is because the controller will close the connection with an error if
+        // we hit the timeout, we should instead return the bytes we've fetched so far.
         if (bytesFetched > 0) {
           options?.onIncompleteDownload?.("SERVER_ERROR", error as Error);
           controller.close();


### PR DESCRIPTION
EVG-19623

### Description 
* Limits the maximum file size to 2.5 GB
* Ensures we still show a log if the server cancels the request

### Screenshots

https://user-images.githubusercontent.com/4605522/232575596-f79451d3-36a3-4b33-8277-a20f540d7a90.mov


### Testing 
Update the `downloadSizeLimit` to be a size small enough that you can test against local data
Set the browser tab to offline to mimic the request being closed by the load balancer.

