### PR TITLE
EVG-18993 Fix flaky virtualization cypress tests

### DIFF
--- a/cypress/integration/ansiiLogs/ansii_logView.ts
+++ b/cypress/integration/ansiiLogs/ansii_logView.ts
@@ -138,7 +138,7 @@ describe("Jump to line", () => {
   });
 
   it("should be able to use the bookmarks bar to jump to a line when there are collapsed rows", () => {
-    cy.visit(`${logLink}?bookmarks=0,297&filters=100pass`);
+    cy.visit(`${logLink}?filters=100pass`);
     cy.dataCy("log-row-56").dblclick({ force: true });
     cy.dataCy("bookmark-56").should("be.visible");
 
@@ -150,7 +150,7 @@ describe("Jump to line", () => {
   });
 
   it("visiting a log with a share line should jump to that line on page load", () => {
-    cy.visit(`${logLink}?bookmarks=0,297&shareLine=200`);
+    cy.visit(`${logLink}?shareLine=200`);
     cy.dataCy("log-row-200").should("be.visible");
   });
 });

--- a/cypress/integration/resmokeLogs/resmoke_logView.ts
+++ b/cypress/integration/resmokeLogs/resmoke_logView.ts
@@ -184,7 +184,7 @@ describe("Jump to line", () => {
   });
 
   it("should be able to use the bookmarks bar to jump to a line when there are collapsed rows", () => {
-    cy.visit(`${logLink}?bookmarks=0,11079&filters=100repl_hb`);
+    cy.visit(`${logLink}?filters=100repl_hb`);
     cy.dataCy("log-row-30").should("be.visible").dblclick({ force: true });
     cy.url().should("include", "bookmarks=0,30,11079");
     cy.dataCy("bookmark-30").should("be.visible");
@@ -197,7 +197,7 @@ describe("Jump to line", () => {
   });
 
   it("visiting a log with a share line should jump to that line on page load", () => {
-    cy.visit(`${logLink}?bookmarks=0,11079&shareLine=200`);
+    cy.visit(`${logLink}?shareLine=200`);
     cy.dataCy("log-row-200").should("be.visible");
   });
 });


### PR DESCRIPTION
EVG-18993

### Description 
Looks like the test flakes from #252 were flakier than I thought. They passed twice on the pr but flaked after merging into main. This PR should fix the flakes. 

### Testing 
I ran the e2e tests 8 times in this patch to validate that they don't flake anymore.
https://spruce.mongodb.com/version/6446d030c9ec444826a0d3ff/tasks

