### PR TITLE
EVG-19008: Implement collapsed row redesign

### DIFF
--- a/src/components/LogRow/CollapsedRow/CollapsedRow.test.tsx
+++ b/src/components/LogRow/CollapsedRow/CollapsedRow.test.tsx
@@ -23,7 +23,7 @@ describe("collapsedRow", () => {
         wrapper: wrapper(logLines),
       }
     );
-    expect(screen.getByText("11 lines skipped")).toBeInTheDocument();
+    expect(screen.getByText("11 Lines Skipped")).toBeInTheDocument();
   });
 
   it("should call expandLines function with the correct arguments when expanding 5 lines", async () => {
@@ -40,7 +40,7 @@ describe("collapsedRow", () => {
       }
     );
     const expandFiveButton = screen.getByRole("button", {
-      name: "Expand Icon 5 Above and Below",
+      name: "5 Above & Below",
     });
     expect(expandFiveButton).toBeEnabled();
     await user.click(expandFiveButton);
@@ -65,7 +65,7 @@ describe("collapsedRow", () => {
       }
     );
     const expandFiveButton = screen.getByRole("button", {
-      name: "Expand Icon All",
+      name: "All",
     });
     await user.click(expandFiveButton);
     expect(expandLines).toHaveBeenCalledTimes(1);
@@ -84,7 +84,7 @@ describe("collapsedRow", () => {
       }
     );
     const expandFiveButton = screen.getByRole("button", {
-      name: "Expand Icon 5 Above and Below",
+      name: "5 Above & Below",
     });
     expect(expandFiveButton).not.toHaveAttribute("aria-disabled", "true");
   });

--- a/src/components/LogRow/CollapsedRow/__snapshots__/CollapsedRow.stories.storyshot
+++ b/src/components/LogRow/CollapsedRow/__snapshots__/CollapsedRow.stories.storyshot
@@ -58,7 +58,7 @@ exports[`storyshots Storyshots components/LogRow/CollapsedRow Collapsed Row Sing
     class="css-1mysoqc"
   >
     <div
-      class="css-xvlhxh"
+      class="css-aapse8"
       data-cy="collapsed-row-0-99"
     >
       <p

--- a/src/components/LogRow/CollapsedRow/__snapshots__/CollapsedRow.stories.storyshot
+++ b/src/components/LogRow/CollapsedRow/__snapshots__/CollapsedRow.stories.storyshot
@@ -58,93 +58,79 @@ exports[`storyshots Storyshots components/LogRow/CollapsedRow Collapsed Row Sing
     class="css-1mysoqc"
   >
     <div
-      class="css-1hak4ne"
+      class="css-xvlhxh"
       data-cy="collapsed-row-0-99"
     >
+      <p
+        class="css-end8kr leafygreen-ui-1yli3c0"
+      >
+        100 Lines Skipped
+      </p>
       <div
-        class="css-end8kr leafygreen-ui-114muox"
+        class="css-10oczdc"
       >
-        100 lines skipped
+        <button
+          aria-disabled="false"
+          class="lg-ui-button-0000 leafygreen-ui-iff687"
+          type="button"
+        >
+          <div
+            class="leafygreen-ui-v038xi"
+          />
+          <div
+            class="leafygreen-ui-1hhc9ms"
+          >
+            <svg
+              alt=""
+              aria-hidden="true"
+              class="leafygreen-ui-11cndel"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.527 1.21a.638.638 0 01.948 0l3.327 3.563c.422.452.123 1.227-.475 1.227H4.673c-.599 0-.898-.775-.476-1.227l3.33-3.562zm3.8 8.79c.598 0 .897.775.475 1.228l-3.327 3.56a.638.638 0 01-.948 0l-3.33-3.56C3.775 10.775 4.074 10 4.673 10h6.654z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+            All
+          </div>
+        </button>
+        <button
+          aria-disabled="false"
+          class="lg-ui-button-0000 leafygreen-ui-iff687"
+          type="button"
+        >
+          <div
+            class="leafygreen-ui-v038xi"
+          />
+          <div
+            class="leafygreen-ui-1hhc9ms"
+          >
+            <svg
+              alt=""
+              aria-hidden="true"
+              class="leafygreen-ui-11cndel"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.527 1.21a.638.638 0 01.948 0l3.327 3.563c.422.452.123 1.227-.475 1.227H4.673c-.599 0-.898-.775-.476-1.227l3.33-3.562zm3.8 8.79c.598 0 .897.775.475 1.228l-3.327 3.56a.638.638 0 01-.948 0l-3.33-3.56C3.775 10.775 4.074 10 4.673 10h6.654z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+            5
+             Above & Below
+          </div>
+        </button>
       </div>
-      <button
-        aria-disabled="false"
-        class="lg-ui-button-0000 leafygreen-ui-iff687 css-7d8zx8"
-        type="button"
-      >
-        <div
-          class="leafygreen-ui-v038xi"
-        />
-        <div
-          class="leafygreen-ui-1hhc9ms"
-        >
-          <svg
-            aria-label="Expand Icon"
-            class="leafygreen-ui-11cndel"
-            fill="none"
-            height="16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M14 3v2.5a.5.5 0 1 1-1 0V4l-2.5 2.5a.707.707 0 0 1-1-1L12 3h-1.5a.5.5 0 1 1 0-1H13a1 1 0 0 1 1 1Z"
-              fill="#001E2B"
-            />
-            <path
-              d="M12 3h-1.5a.5.5 0 1 1 0-1H13a1 1 0 0 1 1 1v2.5a.5.5 0 0 1-1 0V4m-1-1a1 1 0 0 1 1 1m-1-1L9.5 5.5a.707.707 0 0 0 1 1L13 4"
-              stroke="#001E2B"
-            />
-            <path
-              d="M2 12V9a.5.5 0 1 1 1 0v2l2.5-2.5a.707.707 0 1 1 1 1L4 12h1.5a.5.5 0 1 1 0 1H3a1 1 0 0 1-1-1Z"
-              fill="#001E2B"
-            />
-            <path
-              d="M4 12h1.5a.5.5 0 0 1 0 1H3a1 1 0 0 1-1-1V9a.5.5 0 0 1 1 0v2m1 1a1 1 0 0 1-1-1m1 1 2.5-2.5a.707.707 0 1 0-1-1L3 11"
-              stroke="#001E2B"
-            />
-          </svg>
-          All
-        </div>
-      </button>
-      <button
-        aria-disabled="false"
-        class="lg-ui-button-0000 leafygreen-ui-iff687 css-7d8zx8"
-        type="button"
-      >
-        <div
-          class="leafygreen-ui-v038xi"
-        />
-        <div
-          class="leafygreen-ui-1hhc9ms"
-        >
-          <svg
-            aria-label="Expand Icon"
-            class="leafygreen-ui-11cndel"
-            fill="none"
-            height="16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M14 3v2.5a.5.5 0 1 1-1 0V4l-2.5 2.5a.707.707 0 0 1-1-1L12 3h-1.5a.5.5 0 1 1 0-1H13a1 1 0 0 1 1 1Z"
-              fill="#001E2B"
-            />
-            <path
-              d="M12 3h-1.5a.5.5 0 1 1 0-1H13a1 1 0 0 1 1 1v2.5a.5.5 0 0 1-1 0V4m-1-1a1 1 0 0 1 1 1m-1-1L9.5 5.5a.707.707 0 0 0 1 1L13 4"
-              stroke="#001E2B"
-            />
-            <path
-              d="M2 12V9a.5.5 0 1 1 1 0v2l2.5-2.5a.707.707 0 1 1 1 1L4 12h1.5a.5.5 0 1 1 0 1H3a1 1 0 0 1-1-1Z"
-              fill="#001E2B"
-            />
-            <path
-              d="M4 12h1.5a.5.5 0 0 1 0 1H3a1 1 0 0 1-1-1V9a.5.5 0 0 1 1 0v2m1 1a1 1 0 0 1-1-1m1 1 2.5-2.5a.707.707 0 1 0-1-1L3 11"
-              stroke="#001E2B"
-            />
-          </svg>
-          5
-           Above and Below
-        </div>
-      </button>
     </div>
   </div>
 </div>

--- a/src/components/LogRow/CollapsedRow/index.tsx
+++ b/src/components/LogRow/CollapsedRow/index.tsx
@@ -85,7 +85,7 @@ CollapsedRow.displayName = "CollapsedRow";
 const CollapsedLineWrapper = styled.div`
   display: flex;
   align-items: center;
-  background-color: #f4f5f5;
+  background-color: #f4f5f5; // Custom gray background color.
   padding: 2px 0;
   padding-left: ${size.l};
 `;

--- a/src/components/LogRow/CollapsedRow/index.tsx
+++ b/src/components/LogRow/CollapsedRow/index.tsx
@@ -1,16 +1,12 @@
 import { useTransition } from "react";
 import styled from "@emotion/styled";
 import Button from "@leafygreen-ui/button";
-import { palette } from "@leafygreen-ui/palette";
-import { Overline } from "@leafygreen-ui/typography";
+import { Body } from "@leafygreen-ui/typography";
 import { useLogWindowAnalytics } from "analytics";
 import Icon from "components/Icon";
 import { size } from "constants/tokens";
-import { OverlineType } from "types/leafygreen";
 import { ExpandedLines } from "types/logs";
 import { RootRowProps } from "../types";
-
-const { gray } = palette;
 
 const SKIP_NUMBER = 5;
 
@@ -32,7 +28,7 @@ const CollapsedRow: React.FC<CollapsedRowProps> = ({
 
   const canExpandFive = SKIP_NUMBER * 2 < numCollapsed;
   const lineText =
-    numCollapsed !== 1 ? `${numCollapsed} lines skipped` : "1 line skipped";
+    numCollapsed !== 1 ? `${numCollapsed} Lines Skipped` : "1 Line Skipped";
 
   const expandFive = () => {
     if (canExpandFive) {
@@ -63,21 +59,23 @@ const CollapsedRow: React.FC<CollapsedRowProps> = ({
 
   return (
     <CollapsedLineWrapper data-cy={`collapsed-row-${start}-${end}`}>
-      <StyledOverline>{lineText}</StyledOverline>
-      <StyledButton
-        leftGlyph={<Icon glyph="Expand" />}
-        onClick={expandAll}
-        size="xsmall"
-      >
-        All
-      </StyledButton>
-      <StyledButton
-        leftGlyph={<Icon glyph="Expand" />}
-        onClick={expandFive}
-        size="xsmall"
-      >
-        {SKIP_NUMBER} Above and Below
-      </StyledButton>
+      <StyledBody>{lineText}</StyledBody>
+      <ButtonContainer>
+        <Button
+          leftGlyph={<Icon glyph="UpDownCarets" />}
+          onClick={expandAll}
+          size="xsmall"
+        >
+          All
+        </Button>
+        <Button
+          leftGlyph={<Icon glyph="UpDownCarets" />}
+          onClick={expandFive}
+          size="xsmall"
+        >
+          {SKIP_NUMBER} Above & Below
+        </Button>
+      </ButtonContainer>
     </CollapsedLineWrapper>
   );
 };
@@ -87,19 +85,18 @@ CollapsedRow.displayName = "CollapsedRow";
 const CollapsedLineWrapper = styled.div`
   display: flex;
   align-items: center;
-  background-color: ${gray.light2}8C;
+  background-color: #f4f5f5;
+  padding: 2px 0;
   padding-left: ${size.l};
 `;
 
-const StyledOverline = styled<OverlineType>(Overline)`
+const StyledBody = styled(Body)`
   width: 150px;
 `;
 
-const StyledButton = styled(Button)`
-  margin-left: ${size.xs};
-  max-height: ${size.s};
-  border-radius: ${size.xxs};
-  font-size: 12px;
+const ButtonContainer = styled.div`
+  display: flex;
+  gap: ${size.xs};
 `;
 
 export default CollapsedRow;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2538,13 +2538,19 @@ export type WebhookInput = {
 export type WebhookSubscriber = {
   __typename?: "WebhookSubscriber";
   headers: Array<Maybe<WebhookHeader>>;
+  minDelayMs: Scalars["Int"];
+  retries: Scalars["Int"];
   secret: Scalars["String"];
+  timeoutMs: Scalars["Int"];
   url: Scalars["String"];
 };
 
 export type WebhookSubscriberInput = {
   headers: Array<InputMaybe<WebhookHeaderInput>>;
+  minDelayMs?: InputMaybe<Scalars["Int"]>;
+  retries?: InputMaybe<Scalars["Int"]>;
   secret: Scalars["String"];
+  timeoutMs?: InputMaybe<Scalars["Int"]>;
   url: Scalars["String"];
 };
 


### PR DESCRIPTION
EVG-19008

### Description 
This PR updates the collapsed row according to Lara's designs in Figma. 

Notable changes:
* Text style is `Body`, not`Overline`
* Expand icon is vertical, not diagonal
* Row is thicker. Kind of nervous about this one! 🧍

### Screenshots
<img width="706" alt="Screenshot 2023-05-03 at 2 11 02 PM" src="https://user-images.githubusercontent.com/47064971/236007723-37bac23d-0863-4268-8d9e-40f282995cde.png">


### Testing 
- Tests should pass
