### PR TITLE
EVG-18898 upgrade mongo db version

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -352,10 +352,19 @@ functions:
       params:
         env:
           gobin: ${goroot}/bin/go
-          MONGODB_URL: ${mongodb_url_50}
-          DECOMPRESS: ${decompress}
+          MONGODB_URL: ${mongodb_url_60}
+          MONGODB_DECOMPRESS: ${decompress}
         working_dir: parsley/evergreen
         command: make get-mongodb
+    - command: subprocess.exec
+      type: setup
+      params:
+        env:
+          gobin: ${goroot}/bin/go
+          MONGOSH_URL: ${mongosh_url}
+          MONGOSH_DECOMPRESS: ${decompress}
+        working_dir: parsley/evergreen
+        command: make get-mongosh
     - command: subprocess.exec
       type: setup
       params:
@@ -487,13 +496,14 @@ tasks:
     - func: send-email
 
 buildvariants:
-  - name: ubuntu2004-small
-    display_name: Ubuntu 20.04 (small)
+  - name: ubuntu2204-small
+    display_name: Ubuntu 22.04 (small)
     expansions:
-      mongodb_url_50: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.14.tgz
+      mongodb_url_60: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.6.tgz
+      mongosh_url: https://downloads.mongodb.com/compass/mongosh-1.9.0-linux-x64.tgz
       node_version: 16.17.0
     run_on:
-      - ubuntu2004-small
+      - ubuntu2204-small
     modules:
       - evergreen
     tasks:
@@ -509,13 +519,14 @@ buildvariants:
         patchable: false
         priority: 100
 
-  - name: ubuntu2004-large
-    display_name: Ubuntu 20.04 (large)
+  - name: ubuntu2204-large
+    display_name: Ubuntu 22.04 (large)
     expansions:
-      mongodb_url_50: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.14.tgz
+      mongodb_url_60: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.6.tgz
+      mongosh_url: https://downloads.mongodb.com/compass/mongosh-1.9.0-linux-x64.tgz
       node_version: 16.17.0
     run_on:
-      - ubuntu2004-large
+      - ubuntu2204-large
     modules:
       - evergreen
       - logkeeper


### PR DESCRIPTION
[EVG-18898](https://jira.mongodb.org/browse/EVG-18898)

### Description 
Same idea as https://github.com/evergreen-ci/spruce/pull/1844. This will upgrade the db to be in sync with evergreen's post https://github.com/evergreen-ci/evergreen/pull/6542. Also upgrade to ubuntu22.04. We're all clear to upgrade the go version as well but that's not here since it's configured by a project variable.

### Screenshots
N/A

### Testing 
Made [a patch](https://spruce.mongodb.com/version/646e64a30305b9ddaa5b762a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) to test with the evergreen changes as a module (since this PRs test's won't have them).

### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/6542
