### PR TITLE
EVG-20341: Fix condition for displaying project filters

### DIFF
--- a/src/components/ProjectFiltersModal/index.tsx
+++ b/src/components/ProjectFiltersModal/index.tsx
@@ -86,22 +86,26 @@ const ProjectFiltersModal: React.FC<ProjectFiltersModalProps> = ({
       title="Project Filters"
     >
       <Scrollable>
-        {parsleyFilters?.map((filter) => (
-          <ProjectFilter
-            key={filter.expression}
-            active={!!filters.find((f) => f.name === filter.expression)}
-            addFilter={(filterToAdd) =>
-              dispatch({ type: "ADD_FILTER", filterToAdd })
-            }
-            filter={filter}
-            removeFilter={(filterToRemove) => {
-              dispatch({ type: "REMOVE_FILTER", filterToRemove });
-            }}
-            selected={
-              !!state.selectedFilters.find((f) => f.name === filter.expression)
-            }
-          />
-        )) ?? (
+        {parsleyFilters && parsleyFilters.length > 0 ? (
+          parsleyFilters.map((filter) => (
+            <ProjectFilter
+              key={filter.expression}
+              active={!!filters.find((f) => f.name === filter.expression)}
+              addFilter={(filterToAdd) =>
+                dispatch({ type: "ADD_FILTER", filterToAdd })
+              }
+              filter={filter}
+              removeFilter={(filterToRemove) => {
+                dispatch({ type: "REMOVE_FILTER", filterToRemove });
+              }}
+              selected={
+                !!state.selectedFilters.find(
+                  (f) => f.name === filter.expression
+                )
+              }
+            />
+          ))
+        ) : (
           <Body data-cy="no-filters-message">
             No filters have been defined for this project.
           </Body>

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -339,6 +339,12 @@ export type GeneralSubscription = {
   triggerData?: Maybe<Scalars["StringMap"]>;
 };
 
+export type GitTag = {
+  __typename?: "GitTag";
+  pusher: Scalars["String"];
+  tag: Scalars["String"];
+};
+
 export type GithubCheckSubscriber = {
   __typename?: "GithubCheckSubscriber";
   owner: Scalars["String"];
@@ -2461,6 +2467,7 @@ export type Version = {
   errors: Array<Scalars["String"]>;
   externalLinksForMetadata: Array<ExternalLinkForMetadata>;
   finishTime?: Maybe<Scalars["Time"]>;
+  gitTags?: Maybe<Array<GitTag>>;
   id: Scalars["String"];
   isPatch: Scalars["Boolean"];
   manifest?: Maybe<Manifest>;


### PR DESCRIPTION
EVG-20341

### Description 
This PR fixes a small problem where we shouldn't just check if `parsleyFilters` is null, we should also check if the length is 0 to show the "no filters available" message.