### PR TITLE
EVG-19861: Fix filter crash bug

### DIFF
--- a/src/components/PaginatedVirtualList/usePaginatedVirtualList.test.ts
+++ b/src/components/PaginatedVirtualList/usePaginatedVirtualList.test.ts
@@ -154,6 +154,25 @@ describe("usePaginatedVirtualList", () => {
     });
   });
 
+  it("should reset the page to 0 if the row count is less than the page size", () => {
+    const { rerender, result } = renderHook(
+      ({ overrideRowCount }) =>
+        usePaginatedVirtualList({
+          rowCount: overrideRowCount,
+          paginationThreshold,
+          paginationOffset,
+          ref,
+        }),
+      { initialProps: { overrideRowCount: rowCount } }
+    );
+    act(() => {
+      result.current.scrollToNextPage();
+    });
+    expect(result.current.currentPage).toBe(1);
+    rerender({ overrideRowCount: 1000 });
+    expect(result.current.currentPage).toBe(0);
+  });
+
   describe("scrolling to the previous page", () => {
     it("should reflect offset when not on the first page and should scroll to compensate for offset", () => {
       const scrollToIndexMock = jest.fn();

--- a/src/components/PaginatedVirtualList/usePaginatedVirtualList.ts
+++ b/src/components/PaginatedVirtualList/usePaginatedVirtualList.ts
@@ -49,6 +49,13 @@ const usePaginatedVirtualList = ({
     }
   }, [currentPage]);
 
+  // Reset the page to 0 if the row count is less than a page length, but we're not on the first page (e.g. if a filter is applied that significantly shortens the row count).
+  useEffect(() => {
+    if (rowCount < paginationThreshold && currentPage !== 0) {
+      setCurrentPage(0);
+    }
+  }, [currentPage, paginationThreshold, rowCount]);
+
   // The following useEffect is necessary to scroll to the correct position when the user
   // scrolls to the next or previous page.
   useEffect(() => {

--- a/src/components/PaginatedVirtualList/utils.ts
+++ b/src/components/PaginatedVirtualList/utils.ts
@@ -20,6 +20,11 @@ const calculatePageSize = (options: calculatePageSizeOptions) => {
     return Math.min(maxPageSize, totalItemCount);
   }
 
+  // If we have fewer items than fit on one page, the remainder is equal to the total count.
+  if (totalItemCount <= maxPageSize) {
+    return totalItemCount;
+  }
+
   const remainingItems = totalItemCount - maxPageSize * currentPage;
 
   return Math.min(maxPageSize, remainingItems);

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -352,6 +352,7 @@ export type Expansion = {
 export type ExternalLink = {
   __typename?: "ExternalLink";
   displayName: Scalars["String"];
+  requesters: Array<Scalars["String"]>;
   urlTemplate: Scalars["String"];
 };
 
@@ -363,6 +364,7 @@ export type ExternalLinkForMetadata = {
 
 export type ExternalLinkInput = {
   displayName: Scalars["String"];
+  requesters?: InputMaybe<Array<Scalars["String"]>>;
   urlTemplate: Scalars["String"];
 };
 


### PR DESCRIPTION
EVG-19861

### Description 
<!-- Add description, context, thought process, etc -->
- A crash was occurring when a user introduced a change (via filter, etc.) that caused the row count to be less than the max page size while not on the zeroth page. This led to the page size being calculated as a negative number.
- When this occurs, return the row count as the total page size and reset the page index to 0.

### Testing 
<!-- Add a description of how you tested it -->
- Added unit test that currently fails on `main`