### PR TITLE
EVG-20172: Fix position of share icon

### DIFF
--- a/src/components/LogRow/AnsiiRow/__snapshots__/AnsiiRow.stories.storyshot
+++ b/src/components/LogRow/AnsiiRow/__snapshots__/AnsiiRow.stories.storyshot
@@ -37,7 +37,7 @@ exports[`storyshots Storyshots components/LogRow/AnsiiRow Single Line 1`] = `
   >
     <svg
       aria-label="Link Icon"
-      class="css-1w92y2k"
+      class="css-1ygh0vb"
       data-cy="log-link-0"
       fill="none"
       height="14"

--- a/src/components/LogRow/AnsiiRow/__snapshots__/AnsiiRow.stories.storyshot
+++ b/src/components/LogRow/AnsiiRow/__snapshots__/AnsiiRow.stories.storyshot
@@ -56,7 +56,7 @@ exports[`storyshots Storyshots components/LogRow/AnsiiRow Single Line 1`] = `
       />
     </svg>
     <pre
-      class="css-f84hln"
+      class="css-svevlr"
     />
     <pre
       class="css-5l1bqm"

--- a/src/components/LogRow/BaseRow/index.tsx
+++ b/src/components/LogRow/BaseRow/index.tsx
@@ -104,7 +104,7 @@ const BaseRow: React.FC<BaseRowProps> = ({
       onDoubleClick={handleDoubleClick}
       shared={shared}
     >
-      <StyledIcon
+      <ShareIcon
         data-cy={`log-link-${lineNumber}`}
         glyph={shared ? "ArrowWithCircle" : "Link"}
         onClick={handleClick}
@@ -203,11 +203,12 @@ const RowContainer = styled.div<{
   }
 `;
 
-const StyledIcon = styled(Icon)`
+const ShareIcon = styled(Icon)`
   cursor: pointer;
   user-select: none;
   flex-shrink: 0;
-  align-self: center;
+  margin-left: ${size.xxs};
+  margin-top: 2px;
 `;
 
 const Index = styled.pre<{ lineNumber: number }>`

--- a/src/components/LogRow/BaseRow/index.tsx
+++ b/src/components/LogRow/BaseRow/index.tsx
@@ -215,7 +215,7 @@ const Index = styled.pre<{ lineNumber: number }>`
   width: ${size.xl};
   margin-top: 0;
   margin-bottom: 0;
-  margin-left: ${size.s};
+  margin-left: ${size.xs};
   margin-right: ${size.s};
   flex-shrink: 0;
 

--- a/src/components/LogRow/ResmokeRow/__snapshots__/ResmokeRow.stories.storyshot
+++ b/src/components/LogRow/ResmokeRow/__snapshots__/ResmokeRow.stories.storyshot
@@ -37,7 +37,7 @@ exports[`storyshots Storyshots components/LogRow/ResmokeRow Single Line 1`] = `
   >
     <svg
       aria-label="Link Icon"
-      class="css-1w92y2k"
+      class="css-1ygh0vb"
       data-cy="log-link-8"
       fill="none"
       height="14"

--- a/src/components/LogRow/ResmokeRow/__snapshots__/ResmokeRow.stories.storyshot
+++ b/src/components/LogRow/ResmokeRow/__snapshots__/ResmokeRow.stories.storyshot
@@ -56,7 +56,7 @@ exports[`storyshots Storyshots components/LogRow/ResmokeRow Single Line 1`] = `
       />
     </svg>
     <pre
-      class="css-1imicns"
+      class="css-1k6nqgv"
     />
     <pre
       class="css-5l1bqm"


### PR DESCRIPTION
EVG-20172

### Description 
This PR makes the share icon position fixed (next to the line number). Also moved the icon to the right a bit.

### Screenshots
<!-- Add screenshots of visible changes -->
<img width="403" alt="Screenshot 2023-07-12 at 9 02 11 PM" src="https://github.com/evergreen-ci/parsley/assets/47064971/bbe80165-ef34-49db-8a01-79a9536155ac">


