### PR TITLE
EVG-18978: Prevent highlights from corrupting HTML tags

### DIFF
--- a/cypress/integration/ansiiLogs/ansii_highlighting.ts
+++ b/cypress/integration/ansiiLogs/ansii_highlighting.ts
@@ -57,4 +57,16 @@ describe("Highlighting", () => {
         expect(colors.size).to.eq(2);
       });
   });
+  it("highlights should not corrupt links", () => {
+    cy.visit(`${logLink}?shareLine=200`);
+    cy.addHighlight("github");
+    cy.addHighlight("storybook");
+    cy.dataCy("log-row-219").within(() => {
+      cy.get("a").should(
+        "have.attr",
+        "href", // href value should not contain any <mark> tags
+        "https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-storyfn"
+      );
+    });
+  });
 });

--- a/src/components/LogRow/BaseRow/Highlighter.test.tsx
+++ b/src/components/LogRow/BaseRow/Highlighter.test.tsx
@@ -36,13 +36,13 @@ describe("highlighter", () => {
 
   describe("highlights", () => {
     it("highlighted terms highlight the matching text", () => {
-      const regexp = /(Test)/gi;
+      const regexp = /(Test)|(blah)/gi;
       renderWithRouterMatch(
         <Highlighter highlights={regexp}>Test blah test blah</Highlighter>
       );
-      expect(screen.queryAllByDataCy("highlight")).toHaveLength(2);
+      expect(screen.queryAllByDataCy("highlight")).toHaveLength(4);
       screen.getAllByDataCy("highlight").forEach((highlight) => {
-        expect(highlight).toHaveTextContent(/test/i);
+        expect(highlight).toHaveTextContent(/test|blah/i);
       });
     });
   });

--- a/src/components/LogRow/BaseRow/Highlighter.test.tsx
+++ b/src/components/LogRow/BaseRow/Highlighter.test.tsx
@@ -1,0 +1,49 @@
+import { renderWithRouterMatch, screen } from "test_utils";
+import Highlighter from "./Highlighter";
+
+describe("highlighter", () => {
+  it("renders the text color correctly", () => {
+    renderWithRouterMatch(
+      <Highlighter color="salmon" data-cy="test-row">
+        Test blah test blah
+      </Highlighter>
+    );
+    expect(screen.getByDataCy("test-row")).toHaveStyle(`color: salmon`);
+  });
+
+  describe("search", () => {
+    it("search term highlights the matching text", () => {
+      const regexp = /Test/gi;
+      renderWithRouterMatch(
+        <Highlighter searchTerm={regexp}>Test blah test blah</Highlighter>
+      );
+      expect(screen.queryAllByDataCy("highlight")).toHaveLength(2);
+      screen.getAllByDataCy("highlight").forEach((highlight) => {
+        expect(highlight).toHaveTextContent(/test/i);
+      });
+    });
+    it("preserves case sensitivity when applying a search", () => {
+      const { rerender } = renderWithRouterMatch(
+        <Highlighter searchTerm={/test/gi}>Test blah test blah</Highlighter>
+      );
+      expect(screen.queryAllByDataCy("highlight")).toHaveLength(2);
+      rerender(
+        <Highlighter searchTerm={/test/g}>Test blah test blah</Highlighter>
+      );
+      expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
+    });
+  });
+
+  describe("highlights", () => {
+    it("highlighted terms highlight the matching text", () => {
+      const regexp = /(Test)/gi;
+      renderWithRouterMatch(
+        <Highlighter highlights={regexp}>Test blah test blah</Highlighter>
+      );
+      expect(screen.queryAllByDataCy("highlight")).toHaveLength(2);
+      screen.getAllByDataCy("highlight").forEach((highlight) => {
+        expect(highlight).toHaveTextContent(/test/i);
+      });
+    });
+  });
+});

--- a/src/components/LogRow/BaseRow/Highlighter.tsx
+++ b/src/components/LogRow/BaseRow/Highlighter.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from "react";
-import renderHtml from "utils/renderHtml";
+import { highlightHtml } from "utils/renderHtml";
 
 interface HighlighterProps {
   ["data-cy"]?: string;
@@ -19,7 +19,7 @@ const Highlighter: React.FC<HighlighterProps> = memo((props) => {
   } = props;
 
   const htmlToRender = useMemo(
-    () => renderHtml(text, searchTerm, highlights),
+    () => highlightHtml(text, searchTerm, highlights),
     [text, searchTerm, highlights]
   );
 

--- a/src/components/LogRow/BaseRow/Highlighter.tsx
+++ b/src/components/LogRow/BaseRow/Highlighter.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from "react";
-import { highlightHtml } from "utils/renderHtml";
+import highlightHtml from "utils/highlightHtml";
 
 interface HighlighterProps {
   ["data-cy"]?: string;

--- a/src/components/LogRow/BaseRow/Highlighter.tsx
+++ b/src/components/LogRow/BaseRow/Highlighter.tsx
@@ -1,0 +1,34 @@
+import { memo, useMemo } from "react";
+import renderHtml from "utils/renderHtml";
+
+interface HighlighterProps {
+  ["data-cy"]?: string;
+  children: string;
+  color?: string;
+  highlights?: RegExp;
+  searchTerm?: RegExp;
+}
+
+const Highlighter: React.FC<HighlighterProps> = memo((props) => {
+  const {
+    children: text,
+    color,
+    "data-cy": dataCy,
+    highlights,
+    searchTerm,
+  } = props;
+
+  const htmlToRender = useMemo(
+    () => renderHtml(text, searchTerm, highlights),
+    [text, searchTerm, highlights]
+  );
+
+  return (
+    <span data-cy={dataCy} style={{ color }}>
+      {htmlToRender}
+    </span>
+  );
+});
+
+Highlighter.displayName = "Highlighter";
+export default Highlighter;

--- a/src/components/LogRow/BaseRow/Row.test.tsx
+++ b/src/components/LogRow/BaseRow/Row.test.tsx
@@ -79,6 +79,7 @@ describe("row", () => {
     const dataTransfer = await user.copy();
     expect(dataTransfer?.getData("text")).toBe("Test Log");
   });
+
   describe("search", () => {
     it("a search term highlights the matching text", () => {
       const regexp = /Test/i;
@@ -89,7 +90,6 @@ describe("row", () => {
       );
       expect(screen.getByDataCy("highlight")).toHaveTextContent("Test");
     });
-
     it("should preserve case sensitivity when applying a search", () => {
       let regexp = /test/i;
       const { rerender } = renderWithRouterMatch(
@@ -138,7 +138,32 @@ describe("row", () => {
       );
       expect(screen.queryByDataCy("highlight")).not.toBeInTheDocument();
     });
+    it("should not highlight the content in hrefs", () => {
+      const logLine = `highlight me <a href="https://donthighlightme.com">highlight me</a> highlight me`;
+      const regexp = /highlight/gi;
+      renderWithRouterMatch(
+        <Row {...rowProps} searchTerm={regexp}>
+          {logLine}
+        </Row>
+      );
+      expect(screen.queryAllByDataCy("highlight")).toHaveLength(3);
+      expect(
+        screen.getByRole("link", { name: "highlight me" })
+      ).toHaveAttribute("href", "https://donthighlightme.com");
+    });
+    it("will highlight content in <> tags if not HTML tag", () => {
+      const logLine = "<Downloading package...>";
+      const regexp = /<Downloading/i;
+      renderWithRouterMatch(
+        <Row {...rowProps} searchTerm={regexp}>
+          {logLine}
+        </Row>
+      );
+      expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
+      expect(screen.getByDataCy("highlight")).toHaveTextContent("<Downloading");
+    });
   });
+
   describe("highlights", () => {
     it("highlighted terms should highlight the matching text", () => {
       const regexp = /Test/i;
@@ -149,9 +174,8 @@ describe("row", () => {
       );
       expect(screen.getByDataCy("highlight")).toHaveTextContent("Test");
     });
-
     it("should highlight every matching term on a line", () => {
-      const regexp = /Test|Log/i;
+      const regexp = /Test|Log/gi;
       renderWithRouterMatch(
         <Row {...rowProps} highlightRegex={regexp}>
           {testLog}
@@ -188,6 +212,30 @@ describe("row", () => {
       screen.getAllByDataCy("highlight").forEach((highlight) => {
         expect(highlight).toHaveTextContent(/Test|Log/i);
       });
+    });
+    it("should not highlight the content in hrefs", () => {
+      const logLine = `highlight me <a href="https://donthighlightme.com">highlight me</a> highlight me`;
+      const highlightRegex = /(highlight)/gi;
+      renderWithRouterMatch(
+        <Row {...rowProps} highlightRegex={highlightRegex}>
+          {logLine}
+        </Row>
+      );
+      expect(screen.queryAllByDataCy("highlight")).toHaveLength(3);
+      expect(
+        screen.getByRole("link", { name: "highlight me" })
+      ).toHaveAttribute("href", "https://donthighlightme.com");
+    });
+    it("will highlight content in <> tags if not HTML tag", () => {
+      const logLine = "<Downloading package...>";
+      const highlightRegex = /(<Downloading)/i;
+      renderWithRouterMatch(
+        <Row {...rowProps} highlightRegex={highlightRegex}>
+          {logLine}
+        </Row>
+      );
+      expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
+      expect(screen.getByDataCy("highlight")).toHaveTextContent("<Downloading");
     });
   });
 });

--- a/src/components/LogRow/BaseRow/Row.test.tsx
+++ b/src/components/LogRow/BaseRow/Row.test.tsx
@@ -3,8 +3,13 @@ import Row from ".";
 
 describe("row", () => {
   it("renders a log line", () => {
-    renderWithRouterMatch(<Row {...rowProps}>{testLog}</Row>);
+    renderWithRouterMatch(
+      <Row {...rowProps} data-cy="test">
+        {testLog}
+      </Row>
+    );
     expect(screen.getByText(testLog)).toBeVisible();
+    expect(screen.getByDataCy("test")).toBeVisible();
   });
 
   it("properly escapes a log line with tags and renders its contents", () => {
@@ -80,8 +85,8 @@ describe("row", () => {
     expect(dataTransfer?.getData("text")).toBe("Test Log");
   });
 
-  describe("search", () => {
-    it("should highlight matching text if it is within range", () => {
+  describe("search / highlights", () => {
+    it("should highlight matching search text if it is within range", () => {
       const regexp = /Test/i;
       renderWithRouterMatch(
         <Row
@@ -97,7 +102,7 @@ describe("row", () => {
       );
       expect(screen.getByDataCy("highlight")).toHaveTextContent("Test");
     });
-    it("should not highlight matching text if it is outside of range", () => {
+    it("should not highlight matching search text if it is outside of range", () => {
       const regexp = /Test/i;
       renderWithRouterMatch(
         <Row
@@ -112,6 +117,15 @@ describe("row", () => {
         </Row>
       );
       expect(screen.queryByDataCy("highlight")).not.toBeInTheDocument();
+    });
+    it("highlighted terms should highlight the matching text", () => {
+      const regexp = /Test/i;
+      renderWithRouterMatch(
+        <Row {...rowProps} highlightRegex={regexp}>
+          {testLog}
+        </Row>
+      );
+      expect(screen.getByDataCy("highlight")).toHaveTextContent("Test");
     });
   });
 });

--- a/src/components/LogRow/BaseRow/Row.test.tsx
+++ b/src/components/LogRow/BaseRow/Row.test.tsx
@@ -151,17 +151,6 @@ describe("row", () => {
         screen.getByRole("link", { name: "highlight me" })
       ).toHaveAttribute("href", "https://donthighlightme.com");
     });
-    it("will highlight content in <> tags if not HTML tag", () => {
-      const logLine = "<Downloading package...>";
-      const regexp = /<Downloading/i;
-      renderWithRouterMatch(
-        <Row {...rowProps} searchTerm={regexp}>
-          {logLine}
-        </Row>
-      );
-      expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
-      expect(screen.getByDataCy("highlight")).toHaveTextContent("<Downloading");
-    });
   });
 
   describe("highlights", () => {
@@ -225,17 +214,6 @@ describe("row", () => {
       expect(
         screen.getByRole("link", { name: "highlight me" })
       ).toHaveAttribute("href", "https://donthighlightme.com");
-    });
-    it("will highlight content in <> tags if not HTML tag", () => {
-      const logLine = "<Downloading package...>";
-      const highlightRegex = /(<Downloading)/i;
-      renderWithRouterMatch(
-        <Row {...rowProps} highlightRegex={highlightRegex}>
-          {logLine}
-        </Row>
-      );
-      expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
-      expect(screen.getByDataCy("highlight")).toHaveTextContent("<Downloading");
     });
   });
 });

--- a/src/components/LogRow/BaseRow/Row.test.tsx
+++ b/src/components/LogRow/BaseRow/Row.test.tsx
@@ -81,31 +81,6 @@ describe("row", () => {
   });
 
   describe("search", () => {
-    it("a search term highlights the matching text", () => {
-      const regexp = /Test/i;
-      renderWithRouterMatch(
-        <Row {...rowProps} searchTerm={regexp}>
-          {testLog}
-        </Row>
-      );
-      expect(screen.getByDataCy("highlight")).toHaveTextContent("Test");
-    });
-    it("should preserve case sensitivity when applying a search", () => {
-      let regexp = /test/i;
-      const { rerender } = renderWithRouterMatch(
-        <Row {...rowProps} searchTerm={regexp}>
-          {testLog}
-        </Row>
-      );
-      expect(screen.getByDataCy("highlight")).toHaveTextContent("Test");
-      regexp = /test/;
-      rerender(
-        <Row {...rowProps} searchTerm={regexp}>
-          {testLog}
-        </Row>
-      );
-      expect(screen.queryByDataCy("highlight")).toBeNull();
-    });
     it("should highlight matching text if it is within range", () => {
       const regexp = /Test/i;
       renderWithRouterMatch(
@@ -137,83 +112,6 @@ describe("row", () => {
         </Row>
       );
       expect(screen.queryByDataCy("highlight")).not.toBeInTheDocument();
-    });
-    it("should not highlight the content in hrefs", () => {
-      const logLine = `highlight me <a href="https://donthighlightme.com">highlight me</a> highlight me`;
-      const regexp = /highlight/gi;
-      renderWithRouterMatch(
-        <Row {...rowProps} searchTerm={regexp}>
-          {logLine}
-        </Row>
-      );
-      expect(screen.queryAllByDataCy("highlight")).toHaveLength(3);
-      expect(
-        screen.getByRole("link", { name: "highlight me" })
-      ).toHaveAttribute("href", "https://donthighlightme.com");
-    });
-  });
-
-  describe("highlights", () => {
-    it("highlighted terms should highlight the matching text", () => {
-      const regexp = /Test/i;
-      renderWithRouterMatch(
-        <Row {...rowProps} highlightRegex={regexp}>
-          {testLog}
-        </Row>
-      );
-      expect(screen.getByDataCy("highlight")).toHaveTextContent("Test");
-    });
-    it("should highlight every matching term on a line", () => {
-      const regexp = /Test|Log/gi;
-      renderWithRouterMatch(
-        <Row {...rowProps} highlightRegex={regexp}>
-          {testLog}
-        </Row>
-      );
-      expect(screen.queryAllByDataCy("highlight")).toHaveLength(2);
-      screen.getAllByDataCy("highlight").forEach((highlight) => {
-        expect(highlight).toHaveTextContent(/Test|Log/i);
-      });
-    });
-    it("should deduplicate highlights and searches on the same string", () => {
-      const regexp = /Test/i;
-      renderWithRouterMatch(
-        <Row {...rowProps} highlightRegex={regexp} searchTerm={regexp}>
-          {testLog}
-        </Row>
-      );
-      expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
-      expect(screen.getByDataCy("highlight")).toHaveTextContent("Test");
-    });
-    it("should show both highlights and searches if they are on the same line", () => {
-      const searchRegex = /Test/i;
-      const highlightRegex = /(Log)/i;
-      renderWithRouterMatch(
-        <Row
-          {...rowProps}
-          highlightRegex={highlightRegex}
-          searchTerm={searchRegex}
-        >
-          {testLog}
-        </Row>
-      );
-      expect(screen.queryAllByDataCy("highlight")).toHaveLength(2);
-      screen.getAllByDataCy("highlight").forEach((highlight) => {
-        expect(highlight).toHaveTextContent(/Test|Log/i);
-      });
-    });
-    it("should not highlight the content in hrefs", () => {
-      const logLine = `highlight me <a href="https://donthighlightme.com">highlight me</a> highlight me`;
-      const highlightRegex = /(highlight)/gi;
-      renderWithRouterMatch(
-        <Row {...rowProps} highlightRegex={highlightRegex}>
-          {logLine}
-        </Row>
-      );
-      expect(screen.queryAllByDataCy("highlight")).toHaveLength(3);
-      expect(
-        screen.getByRole("link", { name: "highlight me" })
-      ).toHaveAttribute("href", "https://donthighlightme.com");
     });
   });
 });

--- a/src/components/LogRow/RowRenderer/index.tsx
+++ b/src/components/LogRow/RowRenderer/index.tsx
@@ -23,12 +23,16 @@ const ParsleyRow: RowRendererFunction = ({ logType, processedLogLines }) => {
     searchLine,
     searchState,
   } = useLogContext();
-  const { searchTerm } = searchState;
   const { prettyPrint, wrap } = preferences;
 
-  const [highlights] = useHighlightParam();
+  const { searchTerm } = searchState;
+  const searchRegex = searchTerm
+    ? new RegExp(`(${searchTerm.source})`, searchTerm.ignoreCase ? "gi" : "g")
+    : undefined;
+
   // Join the highlights into a single regex to match against. Use capture groups
   // to highlight each match.
+  const [highlights] = useHighlightParam();
   const highlightRegex =
     highlights.length > 0
       ? new RegExp(`${highlights.map((h) => `(${h})`).join("|")}`, "gi")
@@ -57,7 +61,7 @@ const ParsleyRow: RowRendererFunction = ({ logType, processedLogLines }) => {
         range={range}
         scrollToLine={scrollToLine}
         searchLine={searchLine}
-        searchTerm={searchTerm}
+        searchTerm={searchRegex}
         wrap={wrap}
       />
     );

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1590,6 +1590,7 @@ export type ProjectAlias = {
   description?: Maybe<Scalars["String"]>;
   gitTag: Scalars["String"];
   id: Scalars["String"];
+  parameters: Array<Parameter>;
   remotePath: Scalars["String"];
   task: Scalars["String"];
   taskTags: Array<Scalars["String"]>;
@@ -1602,6 +1603,7 @@ export type ProjectAliasInput = {
   description?: InputMaybe<Scalars["String"]>;
   gitTag: Scalars["String"];
   id: Scalars["String"];
+  parameters?: InputMaybe<Array<ParameterInput>>;
   remotePath: Scalars["String"];
   task: Scalars["String"];
   taskTags: Array<Scalars["String"]>;

--- a/src/utils/escapeTags/escapeTags.test.ts
+++ b/src/utils/escapeTags/escapeTags.test.ts
@@ -1,0 +1,39 @@
+import { escapeTags } from ".";
+
+describe("escapeTags", () => {
+  it("escapes html tags", () => {
+    expect(escapeTags("<div withProps='test'>some text</div>", {})).toBe(
+      "&lt;div withProps='test'&gt;some text&lt;/div&gt;"
+    );
+    expect(escapeTags("<script>alert('some alert')</script>")).toBe(
+      "&lt;script&gt;alert('some alert')&lt;/script&gt;"
+    );
+  });
+  it("does not escape allowed html tags", () => {
+    expect(
+      escapeTags("<span>some text</span>", {
+        span: [],
+      })
+    ).toBe("<span>some text</span>");
+    expect(
+      escapeTags("<span target='test'>some text</span>", {
+        span: ["target"],
+      })
+    ).toBe('<span target="test">some text</span>');
+  });
+  it("escapes non html tags", () => {
+    expect(escapeTags("<nil>", {})).toBe("&lt;nil&gt;");
+    expect(
+      escapeTags(
+        ` /opt/mongodbtoolchain/revisions/549e9c72ce95de436fb83815796d54a47893c049/stow/gcc-v3.SIC/include/c++/8.5.0/thread:196:13: std::thread::_State_impl<std::thread::_Invoker<std::tuple<mongo::stdx::thread::thread<mongo::ThreadPool::Impl::_startWorkerThread_inlock()::'lambda2'(), 0>(mongo::ThreadPool::Impl::_startWorkerThread_inlock()::'lambda2'())::'lambda'()> > >::_M_run()`
+      )
+    ).toBe(
+      ` /opt/mongodbtoolchain/revisions/549e9c72ce95de436fb83815796d54a47893c049/stow/gcc-v3.SIC/include/c++/8.5.0/thread:196:13: std::thread::_State_impl&lt;std::thread::_Invoker&lt;std::tuple&lt;mongo::stdx::thread::thread&lt;mongo::ThreadPool::Impl::_startWorkerThread_inlock()::'lambda2'(), 0&gt;(mongo::ThreadPool::Impl::_startWorkerThread_inlock()::'lambda2'())::'lambda'()&gt; &gt; &gt;::_M_run()`
+    );
+  });
+  it("escapes deeply nested non html tags", () => {
+    expect(escapeTags("<some::<nested::tag>>")).toBe(
+      "&lt;some::&lt;nested::tag&gt;&gt;"
+    );
+  });
+});

--- a/src/utils/escapeTags/index.ts
+++ b/src/utils/escapeTags/index.ts
@@ -1,15 +1,21 @@
 import xss, { IWhiteList } from "xss";
 
+const allowedTags: IWhiteList = {
+  a: ["href", "target", "rel", "class", "style"],
+  mark: ["style", "data-cy", "color"],
+  span: ["style", "data-cy"],
+};
+
 /**
  * `escapeTags` is a utility function that takes a string with elements that resemble html tags and returns a string that
  * escapes the tags that are not allowed.
  * @param html - the html string to escape
- * @param allowedTags - a mapping of HTML tags and attributes that should not be escaped
+ * @param whiteList - a mapping of HTML tags and attributes that should not be escaped
  * @returns The escaped html string
  */
-const escapeTags = (html: string, allowedTags?: IWhiteList) =>
+const escapeTags = (html: string, whiteList: IWhiteList = allowedTags) =>
   xss(html, {
-    whiteList: allowedTags,
+    whiteList,
   });
 
 export { escapeTags };

--- a/src/utils/highlightHtml/highlightHtml.test.tsx
+++ b/src/utils/highlightHtml/highlightHtml.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "test_utils";
+import highlightHtml from ".";
+
+describe("highlightHtml", () => {
+  it("does not corrupt the content within valid HTML tags/attributes", () => {
+    render(
+      <>
+        {highlightHtml(
+          "<a href='https://donthighlightme.com'>highlight me</a> highlight me <span data-cy='dont-highlight-me'>highlight me</span>",
+          /highlight/gi
+        )}
+      </>
+    );
+    expect(screen.queryAllByDataCy("highlight")).toHaveLength(3);
+    expect(screen.getByDataCy("dont-highlight-me")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "highlight me" })).toHaveAttribute(
+      "href",
+      "https://donthighlightme.com"
+    );
+  });
+  it("can highlight < or > without corrupting valid HTML tags/attributes", () => {
+    render(
+      <>
+        {highlightHtml(
+          "<blah blah> <span data-cy='dont-highlight-me'>blah blah</span>",
+          /</gi
+        )}
+      </>
+    );
+    expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
+    expect(screen.queryByDataCy("highlight")).toHaveTextContent("<");
+    expect(screen.getByDataCy("dont-highlight-me")).toBeInTheDocument();
+  });
+  it("highlights the content inside of <> if it's not a valid HTML tag", () => {
+    render(<>{highlightHtml("<Downloading package...>", /Downloading/gi)}</>);
+    expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
+    expect(screen.getByDataCy("highlight")).toHaveTextContent("Downloading");
+  });
+  it("applies multiple highlights with different colors", () => {
+    render(
+      <>
+        {highlightHtml(
+          "Downloading node package...",
+          undefined,
+          /(Downloading)|(node)|(package)/gi
+        )}
+      </>
+    );
+    expect(screen.queryAllByDataCy("highlight")).toHaveLength(3);
+    const colors = new Set();
+    colors.add(
+      getComputedStyle(screen.queryAllByDataCy("highlight")[0]).backgroundColor
+    );
+    colors.add(
+      getComputedStyle(screen.queryAllByDataCy("highlight")[1]).backgroundColor
+    );
+    colors.add(
+      getComputedStyle(screen.queryAllByDataCy("highlight")[2]).backgroundColor
+    );
+    expect(colors.size).toBe(3);
+  });
+  it("should deduplicate highlights and searches", () => {
+    const regexp = /test/i;
+    render(<>{highlightHtml("This is a test", regexp, regexp)}</>);
+    expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
+    expect(screen.getByDataCy("highlight")).toHaveTextContent("test");
+  });
+  it("should show both highlights and searches if they are on the same line", () => {
+    render(
+      <>
+        {highlightHtml(
+          "building for production...",
+          /building/i,
+          /(production)/i
+        )}
+      </>
+    );
+    expect(screen.queryAllByDataCy("highlight")).toHaveLength(2);
+    screen.getAllByDataCy("highlight").forEach((highlight) => {
+      expect(highlight).toHaveTextContent(/building|production/i);
+    });
+  });
+});

--- a/src/utils/highlightHtml/highlighter.test.tsx
+++ b/src/utils/highlightHtml/highlighter.test.tsx
@@ -1,4 +1,4 @@
-import { highlighter } from ".";
+import { highlighter } from "./highlighter";
 
 describe("highlighter", () => {
   it("should return the text with the matches replaced by the function", () => {

--- a/src/utils/highlightHtml/highlighter.ts
+++ b/src/utils/highlightHtml/highlighter.ts
@@ -1,13 +1,14 @@
 type replaceFunction = (match: string, matchIndex: number) => string;
 
 /**
- * `highlighter` is a function that takes a regular expression, a string, and a function that returns a string with the function applied to the matching elements.
+ * `highlighter` is a function that takes a regular expression, a string, and a function that
+ * returns a string with the function applied to the matching elements.
  * @param regexp - the regular expression to match
  * @param text - the text to match the regular expression against
  * @param replaceFunction - the function to apply to the matching elements
  * @returns a string with the matching elements replaced by the function
  */
-const highlighter = (
+export const highlighter = (
   regexp: RegExp,
   text: string,
   replaceFunction: replaceFunction
@@ -20,5 +21,3 @@ const highlighter = (
     }
     return match;
   });
-
-export { highlighter };

--- a/src/utils/highlightHtml/index.tsx
+++ b/src/utils/highlightHtml/index.tsx
@@ -1,0 +1,63 @@
+import parse, { Text } from "html-react-parser";
+import Highlight, { highlightColorList } from "components/Highlight";
+import { escapeTags } from "utils/escapeTags";
+import { hasOverlappingRegex } from "utils/regex";
+import renderHtml from "utils/renderHtml";
+import { highlighter } from "./highlighter";
+
+/**
+ * `highlightHtml` adds highlights in the form of <mark> tags.
+ * @param html - The html string to parse
+ * @param searchTerm - The active search term as a regex expression
+ * @param highlights - The active highlights as a regex expression
+ * @returns - html string converted to an array of domnodes with highlighted text
+ */
+export const highlightHtml = (
+  html: string = "",
+  searchTerm: RegExp | undefined = undefined,
+  highlights: RegExp | undefined = undefined
+) => {
+  const escapedHtml = escapeTags(html);
+
+  return parse(escapedHtml, {
+    replace: (domNode) => {
+      if (domNode instanceof Text) {
+        let highlightedText = domNode.data;
+
+        if (searchTerm) {
+          highlightedText = highlighter(
+            searchTerm,
+            highlightedText,
+            (match) => `<mark>${match}</mark>`
+          );
+        }
+
+        if (
+          highlights &&
+          !hasOverlappingRegex(searchTerm, highlights, domNode.data)
+        ) {
+          highlightedText = highlighter(
+            highlights,
+            highlightedText,
+            (match, index) =>
+              `<mark color="${
+                highlightColorList[index % highlightColorList.length]
+              }">${match}</mark>`
+          );
+        }
+
+        const highlightedHtml = renderHtml(highlightedText, {
+          preserveAttributes: ["mark"],
+          transform: {
+            mark: Highlight as unknown as React.ReactNode,
+          },
+        });
+
+        // eslint-disable-next-line react/jsx-no-useless-fragment
+        return <>{highlightedHtml}</>;
+      }
+    },
+  });
+};
+
+export default highlightHtml;

--- a/src/utils/regex/index.ts
+++ b/src/utils/regex/index.ts
@@ -7,7 +7,14 @@ import { stringIntersection } from "utils/string";
  * @param text - the text to match the regexes against
  * @returns true if regexes overlap, false otherwise
  */
-const hasOverlappingRegex = (regex1: RegExp, regex2: RegExp, text: string) => {
+const hasOverlappingRegex = (
+  regex1: RegExp | undefined,
+  regex2: RegExp | undefined,
+  text: string
+) => {
+  if (regex1 === undefined || regex2 === undefined) {
+    return false;
+  }
   const regex1Matches = text.match(regex1);
   const regex2Matches = text.match(regex2);
   if (regex1Matches && regex2Matches) {

--- a/src/utils/renderHtml/index.tsx
+++ b/src/utils/renderHtml/index.tsx
@@ -88,20 +88,20 @@ export const parseWithReplace = (
   const escapedHtml = escapeTags(html, allowedTags);
 
   return parse(escapedHtml, {
-    replace: (d) => {
-      if (d instanceof Element) {
-        if (options.transform && options.transform[d.name]) {
-          const SwapComponent = options.transform[d.name];
+    replace: (domNode) => {
+      if (domNode instanceof Element) {
+        if (options.transform && options.transform[domNode.name]) {
+          const SwapComponent = options.transform[domNode.name];
           // SwapComponent is just what ever component we want to return from the transform object
           const extraProps =
             options.preserveAttributes &&
-            options.preserveAttributes.includes(d.name)
-              ? d.attribs
+            options.preserveAttributes.includes(domNode.name)
+              ? domNode.attribs
               : {};
           return (
             // @ts-expect-error
             <SwapComponent className={extraProps.class} {...extraProps}>
-              {domToReact(d.children)}
+              {domToReact(domNode.children)}
             </SwapComponent>
           );
         }

--- a/src/utils/renderHtml/index.tsx
+++ b/src/utils/renderHtml/index.tsx
@@ -47,6 +47,7 @@ const renderHtml = (html: string = "", options: renderHtmlOptions = {}) => {
             options.preserveAttributes.includes(domNode.name)
               ? domNode.attribs
               : {};
+
           return (
             // @ts-expect-error
             <SwapComponent className={extraProps.class} {...extraProps}>
@@ -55,16 +56,17 @@ const renderHtml = (html: string = "", options: renderHtmlOptions = {}) => {
           );
         }
       }
+      return domNode;
     },
   });
 };
 
 /**
- * `highlightHtml` adds highlights in the form of <mark> tags to a text string.
+ * `highlightHtml` adds highlights in the form of <mark> tags.
  * @param html - The html string to parse
  * @param searchTerm - The active search term as a regex expression
  * @param highlights - The active highlights as a regex expression
- * @returns - html string converted to an array of domnodes
+ * @returns - html string converted to an array of domnodes with highlighted text
  */
 export const highlightHtml = (
   html: string = "",

--- a/src/utils/renderHtml/index.tsx
+++ b/src/utils/renderHtml/index.tsx
@@ -1,8 +1,12 @@
 import parse, {
   Element,
   HTMLReactParserOptions,
+  Text,
   domToReact,
 } from "html-react-parser";
+import Highlight, { highlightColorList } from "components/Highlight";
+import { highlighter } from "utils/highlighters";
+import { hasOverlappingRegex } from "utils/regex";
 import { escapeTags } from "./escapeTags";
 
 interface renderHtmlOptions extends HTMLReactParserOptions {
@@ -25,34 +29,82 @@ const allowedTags = {
  * to keep any classes applied to an item you want to swap you can pass it in as part
  * of the preserveAttributes array
  * @param html - The html string to parse
- * @param options - Options to pass to html-react-parser
- * @param options.transform - Map of elements to swap out
- * @param options.preserveAttributes - Array of elements to preserve attributes for
+ * @param searchTerm - The active search term
+ * @param highlights - The active highlights
  * @returns - html string converted to an array of domnodes
  */
-const renderHtml = (html: string = "", options: renderHtmlOptions = {}) => {
+const renderHtml = (
+  html: string = "",
+  searchTerm: RegExp | undefined = undefined,
+  highlights: RegExp | undefined = undefined
+) => {
   const escapedHtml = escapeTags(html, allowedTags);
 
   return parse(escapedHtml, {
     replace: (domNode) => {
-      if (domNode instanceof Element) {
-        if (options.transform && options.transform[domNode.name]) {
-          const SwapComponent = options.transform[domNode.name];
+      if (domNode instanceof Text) {
+        let markedText = domNode.data;
+
+        if (searchTerm) {
+          markedText = highlighter(
+            searchTerm,
+            markedText,
+            (match) => `<mark>${match}</mark>`
+          );
+        }
+
+        if (
+          highlights &&
+          !hasOverlappingRegex(searchTerm, highlights, domNode.data)
+        ) {
+          markedText = highlighter(
+            highlights,
+            markedText,
+            (match, index) =>
+              `<mark color="${
+                highlightColorList[index % highlightColorList.length]
+              }">${match}</mark>`
+          );
+        }
+
+        const render = parseWithReplace(markedText, {
+          preserveAttributes: ["mark"],
+          transform: {
+            mark: Highlight as unknown as React.ReactNode,
+          },
+        });
+
+        // eslint-disable-next-line react/jsx-no-useless-fragment
+        return <>{render}</>;
+      }
+    },
+  });
+};
+
+export const parseWithReplace = (
+  html: string = "",
+  options: renderHtmlOptions = {}
+) => {
+  const escapedHtml = escapeTags(html, allowedTags);
+
+  return parse(escapedHtml, {
+    replace: (d) => {
+      if (d instanceof Element) {
+        if (options.transform && options.transform[d.name]) {
+          const SwapComponent = options.transform[d.name];
           // SwapComponent is just what ever component we want to return from the transform object
           const extraProps =
             options.preserveAttributes &&
-            options.preserveAttributes.includes(domNode.name)
-              ? domNode.attribs
+            options.preserveAttributes.includes(d.name)
+              ? d.attribs
               : {};
-
           return (
             // @ts-expect-error
             <SwapComponent className={extraProps.class} {...extraProps}>
-              {domToReact(domNode.children)}
+              {domToReact(d.children)}
             </SwapComponent>
           );
         }
-        return domNode;
       }
     },
   });

--- a/src/utils/renderHtml/index.tsx
+++ b/src/utils/renderHtml/index.tsx
@@ -1,13 +1,9 @@
 import parse, {
   Element,
   HTMLReactParserOptions,
-  Text,
   domToReact,
 } from "html-react-parser";
-import Highlight, { highlightColorList } from "components/Highlight";
-import { highlighter } from "utils/highlighters";
-import { hasOverlappingRegex } from "utils/regex";
-import { escapeTags } from "./escapeTags";
+import { escapeTags } from "utils/escapeTags";
 
 interface renderHtmlOptions extends HTMLReactParserOptions {
   preserveAttributes?: string[];
@@ -15,12 +11,6 @@ interface renderHtmlOptions extends HTMLReactParserOptions {
     [key: string]: React.ReactNode;
   };
 }
-
-const allowedTags = {
-  a: ["href", "target", "rel", "class", "style"],
-  mark: ["style", "data-cy", "color"],
-  span: ["style", "data-cy"],
-};
 
 /**
  * `renderHtml` takes a string and converts it into an array of domnodes for parsing.
@@ -34,7 +24,7 @@ const allowedTags = {
  * @returns - html string converted to an array of domnodes
  */
 const renderHtml = (html: string = "", options: renderHtmlOptions = {}) => {
-  const escapedHtml = escapeTags(html, allowedTags);
+  const escapedHtml = escapeTags(html);
 
   return parse(escapedHtml, {
     replace: (domNode) => {
@@ -61,59 +51,5 @@ const renderHtml = (html: string = "", options: renderHtmlOptions = {}) => {
   });
 };
 
-/**
- * `highlightHtml` adds highlights in the form of <mark> tags.
- * @param html - The html string to parse
- * @param searchTerm - The active search term as a regex expression
- * @param highlights - The active highlights as a regex expression
- * @returns - html string converted to an array of domnodes with highlighted text
- */
-export const highlightHtml = (
-  html: string = "",
-  searchTerm: RegExp | undefined = undefined,
-  highlights: RegExp | undefined = undefined
-) => {
-  const escapedHtml = escapeTags(html, allowedTags);
-
-  return parse(escapedHtml, {
-    replace: (domNode) => {
-      if (domNode instanceof Text) {
-        let highlightedText = domNode.data;
-
-        if (searchTerm) {
-          highlightedText = highlighter(
-            searchTerm,
-            highlightedText,
-            (match) => `<mark>${match}</mark>`
-          );
-        }
-
-        if (
-          highlights &&
-          !hasOverlappingRegex(searchTerm, highlights, domNode.data)
-        ) {
-          highlightedText = highlighter(
-            highlights,
-            highlightedText,
-            (match, index) =>
-              `<mark color="${
-                highlightColorList[index % highlightColorList.length]
-              }">${match}</mark>`
-          );
-        }
-
-        const highlightedHtml = renderHtml(highlightedText, {
-          preserveAttributes: ["mark"],
-          transform: {
-            mark: Highlight as unknown as React.ReactNode,
-          },
-        });
-
-        // eslint-disable-next-line react/jsx-no-useless-fragment
-        return <>{highlightedHtml}</>;
-      }
-    },
-  });
-};
-
 export default renderHtml;
+export { escapeTags };

--- a/src/utils/renderHtml/index.tsx
+++ b/src/utils/renderHtml/index.tsx
@@ -52,4 +52,3 @@ const renderHtml = (html: string = "", options: renderHtmlOptions = {}) => {
 };
 
 export default renderHtml;
-export { escapeTags };

--- a/src/utils/renderHtml/index.tsx
+++ b/src/utils/renderHtml/index.tsx
@@ -23,68 +23,17 @@ const allowedTags = {
 };
 
 /**
- * `renderHtml` takes a string and converts it into an array of domnodes and
- * parses through them and swaps elements with other elements based on if they are
- * included in the transform object passed in through options. If you would like
- * to keep any classes applied to an item you want to swap you can pass it in as part
- * of the preserveAttributes array
+ * `renderHtml` takes a string and converts it into an array of domnodes for parsing.
+ * Elements are swapped with other elements based on if they are included in the options.transform
+ * object. If you would like to keep any attributes (classnames, styles, etc), you can pass it in
+ * as part of the options.preserveAttributes array.
  * @param html - The html string to parse
- * @param searchTerm - The active search term
- * @param highlights - The active highlights
+ * @param options - Options to pass to html-react-parser
+ * @param options.transform - Map of elements to swap out
+ * @param options.preserveAttributes - Array of elements to preserve attributes for
  * @returns - html string converted to an array of domnodes
  */
-const renderHtml = (
-  html: string = "",
-  searchTerm: RegExp | undefined = undefined,
-  highlights: RegExp | undefined = undefined
-) => {
-  const escapedHtml = escapeTags(html, allowedTags);
-
-  return parse(escapedHtml, {
-    replace: (domNode) => {
-      if (domNode instanceof Text) {
-        let markedText = domNode.data;
-
-        if (searchTerm) {
-          markedText = highlighter(
-            searchTerm,
-            markedText,
-            (match) => `<mark>${match}</mark>`
-          );
-        }
-
-        if (
-          highlights &&
-          !hasOverlappingRegex(searchTerm, highlights, domNode.data)
-        ) {
-          markedText = highlighter(
-            highlights,
-            markedText,
-            (match, index) =>
-              `<mark color="${
-                highlightColorList[index % highlightColorList.length]
-              }">${match}</mark>`
-          );
-        }
-
-        const render = parseWithReplace(markedText, {
-          preserveAttributes: ["mark"],
-          transform: {
-            mark: Highlight as unknown as React.ReactNode,
-          },
-        });
-
-        // eslint-disable-next-line react/jsx-no-useless-fragment
-        return <>{render}</>;
-      }
-    },
-  });
-};
-
-export const parseWithReplace = (
-  html: string = "",
-  options: renderHtmlOptions = {}
-) => {
+const renderHtml = (html: string = "", options: renderHtmlOptions = {}) => {
   const escapedHtml = escapeTags(html, allowedTags);
 
   return parse(escapedHtml, {
@@ -105,6 +54,61 @@ export const parseWithReplace = (
             </SwapComponent>
           );
         }
+      }
+    },
+  });
+};
+
+/**
+ * `highlightHtml` adds highlights in the form of <mark> tags to a text string.
+ * @param html - The html string to parse
+ * @param searchTerm - The active search term as a regex expression
+ * @param highlights - The active highlights as a regex expression
+ * @returns - html string converted to an array of domnodes
+ */
+export const highlightHtml = (
+  html: string = "",
+  searchTerm: RegExp | undefined = undefined,
+  highlights: RegExp | undefined = undefined
+) => {
+  const escapedHtml = escapeTags(html, allowedTags);
+
+  return parse(escapedHtml, {
+    replace: (domNode) => {
+      if (domNode instanceof Text) {
+        let highlightedText = domNode.data;
+
+        if (searchTerm) {
+          highlightedText = highlighter(
+            searchTerm,
+            highlightedText,
+            (match) => `<mark>${match}</mark>`
+          );
+        }
+
+        if (
+          highlights &&
+          !hasOverlappingRegex(searchTerm, highlights, domNode.data)
+        ) {
+          highlightedText = highlighter(
+            highlights,
+            highlightedText,
+            (match, index) =>
+              `<mark color="${
+                highlightColorList[index % highlightColorList.length]
+              }">${match}</mark>`
+          );
+        }
+
+        const highlightedHtml = renderHtml(highlightedText, {
+          preserveAttributes: ["mark"],
+          transform: {
+            mark: Highlight as unknown as React.ReactNode,
+          },
+        });
+
+        // eslint-disable-next-line react/jsx-no-useless-fragment
+        return <>{highlightedHtml}</>;
       }
     },
   });

--- a/src/utils/renderHtml/index.tsx
+++ b/src/utils/renderHtml/index.tsx
@@ -55,8 +55,8 @@ const renderHtml = (html: string = "", options: renderHtmlOptions = {}) => {
             </SwapComponent>
           );
         }
+        return domNode;
       }
-      return domNode;
     },
   });
 };

--- a/src/utils/renderHtml/renderHtml.test.tsx
+++ b/src/utils/renderHtml/renderHtml.test.tsx
@@ -67,7 +67,7 @@ describe("highlightHtml", () => {
       "https://donthighlightme.com"
     );
   });
-  it("can highlight < or > without corrupting HTML tags/attributes", () => {
+  it("can highlight < or > without corrupting valid HTML tags/attributes", () => {
     render(
       <>
         {highlightHtml(
@@ -79,6 +79,11 @@ describe("highlightHtml", () => {
     expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
     expect(screen.queryByDataCy("highlight")).toHaveTextContent("<");
     expect(screen.getByDataCy("dont-highlight-me")).toBeInTheDocument();
+  });
+  it("highlights the content inside of <> if it's not a valid HTML tag", () => {
+    render(<>{highlightHtml("<Downloading package...>", /Downloading/gi)}</>);
+    expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
+    expect(screen.getByDataCy("highlight")).toHaveTextContent("Downloading");
   });
 });
 

--- a/src/utils/renderHtml/renderHtml.test.tsx
+++ b/src/utils/renderHtml/renderHtml.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "test_utils";
-import renderHtml from ".";
+import renderHtml, { parseWithReplace } from ".";
 import { escapeTags } from "./escapeTags";
 
 describe("renderHtml", () => {
@@ -32,14 +32,16 @@ describe("renderHtml", () => {
       "test <mongo::<std:lib >>"
     );
   });
+});
 
+describe("parseWithReplace", () => {
   it("replaces a element with a react component if specified", () => {
     const Component = ({ children }: { children: React.ReactElement }) => (
       <div data-cy="component">✨{children}✨</div>
     );
     render(
       <>
-        {renderHtml("test <span data-cy='element'>string</span>", {
+        {parseWithReplace("test <span data-cy='element'>string</span>", {
           // @ts-expect-error - This is expecting a react component but its an Emotion component which are virtually the same thing
           transform: { span: Component },
         })}

--- a/src/utils/renderHtml/renderHtml.test.tsx
+++ b/src/utils/renderHtml/renderHtml.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "test_utils";
-import renderHtml, { highlightHtml } from ".";
-import { escapeTags } from "./escapeTags";
+import renderHtml from ".";
 
 describe("renderHtml", () => {
   it("renders a plain string with no html", () => {
@@ -47,80 +46,5 @@ describe("renderHtml", () => {
     expect(screen.queryByDataCy("element")).not.toBeInTheDocument();
     expect(screen.getByDataCy("component")).toBeInTheDocument();
     expect(screen.queryByDataCy("component")).toHaveTextContent("✨string✨");
-  });
-});
-
-describe("highlightHtml", () => {
-  it("does not corrupt the content within valid HTML tags/attributes", () => {
-    render(
-      <>
-        {highlightHtml(
-          "<a href='https://donthighlightme.com'>highlight me</a> highlight me <span data-cy='dont-highlight-me'>highlight me</span>",
-          /highlight/gi
-        )}
-      </>
-    );
-    expect(screen.queryAllByDataCy("highlight")).toHaveLength(3);
-    expect(screen.getByDataCy("dont-highlight-me")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "highlight me" })).toHaveAttribute(
-      "href",
-      "https://donthighlightme.com"
-    );
-  });
-  it("can highlight < or > without corrupting valid HTML tags/attributes", () => {
-    render(
-      <>
-        {highlightHtml(
-          "<blah blah> <span data-cy='dont-highlight-me'>blah blah</span>",
-          /</gi
-        )}
-      </>
-    );
-    expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
-    expect(screen.queryByDataCy("highlight")).toHaveTextContent("<");
-    expect(screen.getByDataCy("dont-highlight-me")).toBeInTheDocument();
-  });
-  it("highlights the content inside of <> if it's not a valid HTML tag", () => {
-    render(<>{highlightHtml("<Downloading package...>", /Downloading/gi)}</>);
-    expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
-    expect(screen.getByDataCy("highlight")).toHaveTextContent("Downloading");
-  });
-});
-
-describe("escapeTags", () => {
-  it("escapes html tags", () => {
-    expect(escapeTags("<div withProps='test'>some text</div>", {})).toBe(
-      "&lt;div withProps='test'&gt;some text&lt;/div&gt;"
-    );
-    expect(escapeTags("<script>alert('some alert')</script>")).toBe(
-      "&lt;script&gt;alert('some alert')&lt;/script&gt;"
-    );
-  });
-  it("does not escape allowed html tags", () => {
-    expect(
-      escapeTags("<span>some text</span>", {
-        span: [],
-      })
-    ).toBe("<span>some text</span>");
-    expect(
-      escapeTags("<span target='test'>some text</span>", {
-        span: ["target"],
-      })
-    ).toBe('<span target="test">some text</span>');
-  });
-  it("escapes non html tags", () => {
-    expect(escapeTags("<nil>", {})).toBe("&lt;nil&gt;");
-    expect(
-      escapeTags(
-        ` /opt/mongodbtoolchain/revisions/549e9c72ce95de436fb83815796d54a47893c049/stow/gcc-v3.SIC/include/c++/8.5.0/thread:196:13: std::thread::_State_impl<std::thread::_Invoker<std::tuple<mongo::stdx::thread::thread<mongo::ThreadPool::Impl::_startWorkerThread_inlock()::'lambda2'(), 0>(mongo::ThreadPool::Impl::_startWorkerThread_inlock()::'lambda2'())::'lambda'()> > >::_M_run()`
-      )
-    ).toBe(
-      ` /opt/mongodbtoolchain/revisions/549e9c72ce95de436fb83815796d54a47893c049/stow/gcc-v3.SIC/include/c++/8.5.0/thread:196:13: std::thread::_State_impl&lt;std::thread::_Invoker&lt;std::tuple&lt;mongo::stdx::thread::thread&lt;mongo::ThreadPool::Impl::_startWorkerThread_inlock()::'lambda2'(), 0&gt;(mongo::ThreadPool::Impl::_startWorkerThread_inlock()::'lambda2'())::'lambda'()&gt; &gt; &gt;::_M_run()`
-    );
-  });
-  it("escapes deeply nested non html tags", () => {
-    expect(escapeTags("<some::<nested::tag>>")).toBe(
-      "&lt;some::&lt;nested::tag&gt;&gt;"
-    );
   });
 });


### PR DESCRIPTION
EVG-18978

### Description 
This PR moves the highlight logic into the HTML parser to prevent highlights from corrupting HTML tags.

This approach solves a number of bugs in production including:
* Highlights can mess up log lines that include `<` and `>` since they are escaped to `&gt;` and `&lt;` respectively.
 
Correct line      |  Incorrect line after searching for `g`
:-------------------------:|:-------------------------:
<img width="606" alt="gt_right" src="https://github.com/evergreen-ci/parsley/assets/47064971/3502fd31-fbf3-4465-9562-a7ffa566c080"> | <img width="647" alt="gt_wrong" src="https://github.com/evergreen-ci/parsley/assets/47064971/d2d38dab-b20f-4b4f-8755-02c649ff599c">

* Searching for something like `span` will corrupt the `span` tags added via `ansi_to_html`.

Correct line      |  Incorrect line after searching for `span`
:-------------------------:|:-------------------------:
<img width="589" alt="span_right" src="https://github.com/evergreen-ci/parsley/assets/47064971/34d16d1a-0f8c-4882-a059-4faa57bc4a71"> | <img width="1257" alt="span_wrong" src="https://github.com/evergreen-ci/parsley/assets/47064971/0c19d1c6-0480-49ac-9cc5-81273bb51fde">

* Inconsistencies between searching and highlighting because of escaped vs unescaped text.

Search works, but missing highlight    |  Highlight works, but the search term needs to be escaped
:-------------------------:|:-------------------------:
<img width="690" alt="newbranch-highlight" src="https://github.com/evergreen-ci/parsley/assets/47064971/4a85c187-5a68-49dc-9170-fd9814a0c1bd"> | <img width="655" alt="newbranch-search" src="https://github.com/evergreen-ci/parsley/assets/47064971/d12ee0e0-d8ea-4d97-a021-971be22a9b14">

### Testing 
- Added e2e & unit tests
