### PR TITLE
EVG-20443: set "excludeDisplayNames" flag in TestLogURL query

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2481,6 +2481,7 @@ export type TaskQueueDistro = {
  */
 export type TaskQueueItem = {
   __typename?: "TaskQueueItem";
+  activatedBy: Scalars["String"];
   buildVariant: Scalars["String"];
   displayName: Scalars["String"];
   expectedDuration: Scalars["Duration"];

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2481,7 +2481,6 @@ export type TaskQueueDistro = {
  */
 export type TaskQueueItem = {
   __typename?: "TaskQueueItem";
-  activatedBy: Scalars["String"];
   buildVariant: Scalars["String"];
   displayName: Scalars["String"];
   expectedDuration: Scalars["Duration"];
@@ -2574,6 +2573,7 @@ export type TestFilter = {
  * It's used to filter, sort, and paginate test results of a task.
  */
 export type TestFilterOptions = {
+  excludeDisplayNames?: InputMaybe<Scalars["Boolean"]>;
   groupID?: InputMaybe<Scalars["String"]>;
   limit?: InputMaybe<Scalars["Int"]>;
   page?: InputMaybe<Scalars["Int"]>;

--- a/src/gql/queries/get-test-log-url.graphql
+++ b/src/gql/queries/get-test-log-url.graphql
@@ -1,7 +1,7 @@
 query TestLogURL($taskID: String!, $testName: String!, $execution: Int!) {
   task(taskId: $taskID, execution: $execution) {
     id
-    tests(opts: { testName: $testName }) {
+    tests(opts: { testName: $testName, excludeDisplayNames: true }) {
       testResults {
         id
         logs {


### PR DESCRIPTION
EVG-20443

### Description 
Arjun added an update to resolve Evergreen test log URLs via GQL when possible in https://github.com/evergreen-ci/parsley/pull/343. We need to further specify to exclude display names when filtering on a test name regex since the test results service's filtering functionality favors display names by default and these are not necessarily unique. 

### Testing 
I was able to confirm with evergreen and parsley staging that this query successfully fetches (and thus enables loading) the test result log URL when passed the unique test name (rather than display test name).

### Evergreen PR 
Must be deployed after https://github.com/evergreen-ci/evergreen/pull/6839.
