### PR TITLE
EVG-20601 Update dependabot frequency to once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 10
+      interval: "weekly"
+    open-pull-requests-limit: 3
     commit-message:
       # Prefix all commit messages with "npm"
       prefix: "CHORE(NPM) - "


### PR DESCRIPTION
EVG-20601

### Description
Following up from the UI round table and updating Dependabot to only trigger once a week. 3 per repo should be a nice balance while not being overwhelming for whoever is on call.


