### PR TITLE
EVG-18748: Remove selectedLine redirect

### DIFF
--- a/cypress/integration/routes.ts
+++ b/cypress/integration/routes.ts
@@ -45,27 +45,4 @@ describe("Parsley Routes", () => {
     cy.visit("/this/is/not/a/real/page");
     cy.dataCy("404").should("be.visible");
   });
-
-  // This test block can be deleted in EVG-18748.
-  describe("redirecting", () => {
-    it("should redirect selectedLine to shareLine, preserving all other query params", () => {
-      cy.visit(
-        "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task?bookmarks=0,297&filters=100this%2520is%2520a%2520filter&highlights=this%2520is%2520a%2520highlight&selectedLine=7"
-      );
-      cy.location("search").should("not.contain", "selectedLine");
-      cy.location("search").should(
-        "equal",
-        "?bookmarks=0,297&filters=100this%2520is%2520a%2520filter&highlights=this%2520is%2520a%2520highlight&shareLine=7"
-      );
-    });
-    it("should correctly jump to line when selectedLine is replaced by shareLine param", () => {
-      cy.visit(
-        "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task?bookmarks=0,297&selectedLine=200"
-      );
-      cy.location("search").should("not.contain", "selectedLine");
-      cy.location("search").should("equal", "?bookmarks=0,297&shareLine=200");
-      cy.dataCy("log-row-200").should("be.visible"); // Should have jumped to line 200.
-      cy.get("[data-shared='true']").should("be.visible");
-    });
-  });
 });

--- a/src/constants/queryParams.ts
+++ b/src/constants/queryParams.ts
@@ -4,7 +4,6 @@ enum QueryParams {
   Bookmarks = "bookmarks",
   Filters = "filters",
   ShareLine = "shareLine",
-  SelectedLine = "selectedLine", // Delete this as part of EVG-18748.
   Wrap = "wrap",
   Expandable = "expandable",
   FilterLogic = "filterLogic",

--- a/src/context/LogContext/index.tsx
+++ b/src/context/LogContext/index.tsx
@@ -19,7 +19,7 @@ import {
 import { FilterLogic, LogTypes } from "constants/enums";
 import { QueryParams } from "constants/queryParams";
 import { useFilterParam } from "hooks/useFilterParam";
-import { useQueryParam, useQueryParams } from "hooks/useQueryParam";
+import { useQueryParam } from "hooks/useQueryParam";
 import { ExpandedLines, ProcessedLogLines } from "types/logs";
 import filterLogs from "utils/filterLogs";
 import { getMatchingLines } from "utils/matchingLines";
@@ -78,15 +78,10 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
   children,
   initialLogLines,
 }) => {
-  const [searchParams, setSearchParams] = useQueryParams();
   const [filters] = useFilterParam();
   const [bookmarks] = useQueryParam<number[]>(QueryParams.Bookmarks, []);
   const [shareLine] = useQueryParam<number | undefined>(
     QueryParams.ShareLine,
-    undefined
-  );
-  const [selectedLine] = useQueryParam<number | undefined>(
-    QueryParams.SelectedLine,
     undefined
   );
   const [lowerRange] = useQueryParam(QueryParams.LowerRange, 0);
@@ -152,18 +147,6 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
       expandableRows,
     ]
   );
-
-  // If selectedLine is in the URL, replace it with shareLine.
-  // This block of code can be deleted in EVG-18748.
-  useEffect(() => {
-    if (selectedLine) {
-      setSearchParams({
-        ...searchParams,
-        selectedLine: undefined,
-        shareLine: selectedLine,
-      });
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const getLine = useCallback(
     (lineNumber: number) => state.logs[lineNumber],


### PR DESCRIPTION
EVG-18748

### Description 
<!-- Add description, context, thought process, etc -->
Stop supporting `selectedLine` query param in Parsley URLs now that the TTL has been reached.

### Testing 
<!-- Add a description of how you tested it -->
- Remove tests for redirect support