### PR TITLE
EVG-20175: Avoid calling controller.close() twice

### DIFF
--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -1,6 +1,9 @@
+import { leaveBreadcrumb } from "utils/errorReporting";
+
 type StreamedFileOptions = {
   fileSizeLimit?: number;
 };
+
 /**
  * `fileToStream` is a utility function that converts a File object into a ReadableStream
  * @param file - File to convert to a stream
@@ -31,7 +34,11 @@ const fileToStream = async (
             byteOffset += CHUNK_SIZE;
             bytesRead += CHUNK_SIZE;
             if (options.fileSizeLimit && bytesRead > options.fileSizeLimit) {
-              controller.close();
+              leaveBreadcrumb(
+                "File size limit exceeded",
+                { bytesRead },
+                "process"
+              );
               break;
             }
           }


### PR DESCRIPTION
EVG-20175

### Description 
This part of the code ends up calling `controller.close()` two times, because when it breaks out of the loop it also calls `controller.close()`. I just removed the extra call.

Also added a breadcrumb. (Which will get Sentry-fied in [EVG-20825](https://jira.mongodb.org/browse/EVG-20825))

### Testing 
- Manual testing. Set the file limit to something low (like 2) and uploaded a file and made sure the error went away.