### PR TITLE
EVG-20863: Add userId as custom attribute in New Relic

### DIFF
--- a/src/analytics/useAnalyticAttributes.ts
+++ b/src/analytics/useAnalyticAttributes.ts
@@ -2,17 +2,24 @@ import { useEffect } from "react";
 import { useLogContext } from "context/LogContext";
 
 export const useAnalyticAttributes = () => {
-  const { logMetadata } = useLogContext();
   const { newrelic } = window;
+
+  const { logMetadata } = useLogContext();
   const { logType } = logMetadata || {};
+
+  const userId = localStorage.getItem("userId");
 
   useEffect(() => {
     if (typeof newrelic !== "object") {
       console.debug("Setting logType: ", logType);
+      console.debug("Setting userId: ", userId);
       return;
     }
     if (logType !== undefined) {
       newrelic.setCustomAttribute("logType", logType);
     }
-  }, [logType, newrelic]);
+    if (userId !== null) {
+      newrelic.setCustomAttribute("userId", userId);
+    }
+  }, [userId, logType, newrelic]);
 };


### PR DESCRIPTION
EVG-20863

### Description 
Adds `userId` as a custom attribute in NewRelic. Will be used to provide Will's design project with more analytics.

### Testing 
- Cannot test as we do not have a staging environment for Parsley NewRelic but all I did was copy and paste from Spruce 👀