### PR TITLE
EVG-20176 Rename filter name attribute to expression

### DIFF
--- a/src/components/ProjectFiltersModal/ProjectFilter.tsx
+++ b/src/components/ProjectFiltersModal/ProjectFilter.tsx
@@ -29,8 +29,8 @@ const ProjectFilter: React.FC<ProjectFilterProps> = ({
         caseSensitive: filter.caseSensitive
           ? CaseSensitivity.Sensitive
           : CaseSensitivity.Insensitive,
+        expression: filter.expression,
         matchType: filter.exactMatch ? MatchType.Exact : MatchType.Inverse,
-        name: filter.expression,
         visible: true,
       });
     } else {

--- a/src/components/ProjectFiltersModal/index.tsx
+++ b/src/components/ProjectFiltersModal/index.tsx
@@ -90,7 +90,7 @@ const ProjectFiltersModal: React.FC<ProjectFiltersModalProps> = ({
           parsleyFilters.map((filter) => (
             <ProjectFilter
               key={filter.expression}
-              active={!!filters.find((f) => f.name === filter.expression)}
+              active={!!filters.find((f) => f.expression === filter.expression)}
               addFilter={(filterToAdd) =>
                 dispatch({ filterToAdd, type: "ADD_FILTER" })
               }
@@ -100,7 +100,7 @@ const ProjectFiltersModal: React.FC<ProjectFiltersModalProps> = ({
               }}
               selected={
                 !!state.selectedFilters.find(
-                  (f) => f.name === filter.expression
+                  (f) => f.expression === filter.expression
                 )
               }
             />

--- a/src/components/ProjectFiltersModal/state.ts
+++ b/src/components/ProjectFiltersModal/state.ts
@@ -25,7 +25,7 @@ const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         selectedFilters: state.selectedFilters.filter(
-          (f) => f.name !== action.filterToRemove
+          (f) => f.expression !== action.filterToRemove
         ),
       };
     case "RESET":

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -47,14 +47,14 @@ const Search: React.FC = () => {
   const handleOnSubmit = (selected: string, value: string) => {
     switch (selected) {
       case SearchBarActions.Filter:
-        if (!filters.some((f) => f.name === value)) {
+        if (!filters.some((f) => f.expression === value)) {
           setSearch("");
           setFilters([
             ...filters,
             {
               caseSensitive: CaseSensitivity.Insensitive,
+              expression: value,
               matchType: MatchType.Exact,
-              name: value,
               visible: true,
             },
           ]);

--- a/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/FilterGroup.test.tsx
+++ b/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/FilterGroup.test.tsx
@@ -4,8 +4,8 @@ import FilterGroup from ".";
 
 const defaultFilter = {
   caseSensitive: CaseSensitivity.Insensitive,
+  expression: "myFilter",
   matchType: MatchType.Exact,
-  name: "myFilter",
   visible: true,
 };
 
@@ -18,7 +18,7 @@ describe("filters", () => {
         filter={defaultFilter}
       />
     );
-    expect(screen.getByText(defaultFilter.name)).toBeInTheDocument();
+    expect(screen.getByText(defaultFilter.expression)).toBeInTheDocument();
   });
 
   it("should be able to toggle editing", async () => {
@@ -31,10 +31,10 @@ describe("filters", () => {
       />
     );
     await user.click(screen.getByLabelText("Edit filter"));
-    expect(screen.queryByText(defaultFilter.name)).toBeNull();
+    expect(screen.queryByText(defaultFilter.expression)).toBeNull();
     expect(screen.getByDataCy("edit-filter-name")).toBeInTheDocument();
     expect(screen.getByDataCy("edit-filter-name")).toHaveValue(
-      defaultFilter.name
+      defaultFilter.expression
     );
 
     expect(screen.getByDataCy("edit-filter-name")).toHaveFocus();
@@ -197,7 +197,7 @@ describe("filters", () => {
       <FilterGroup
         deleteFilter={jest.fn()}
         editFilter={editFilter}
-        filter={{ ...defaultFilter, name: "invalid (regex" }}
+        filter={{ ...defaultFilter, expression: "invalid (regex" }}
       />
     );
     expect(
@@ -217,7 +217,7 @@ describe("filters", () => {
       <FilterGroup
         deleteFilter={jest.fn()}
         editFilter={editFilter}
-        filter={{ ...defaultFilter, name: "invalid (regex" }}
+        filter={{ ...defaultFilter, expression: "invalid (regex" }}
       />
     );
     expect(screen.getByLabelText("Hide filter")).toHaveAttribute(
@@ -233,7 +233,7 @@ describe("filters", () => {
       <FilterGroup
         deleteFilter={jest.fn()}
         editFilter={editFilter}
-        filter={{ ...defaultFilter, name: "invalid (regex" }}
+        filter={{ ...defaultFilter, expression: "invalid (regex" }}
       />
     );
     await user.click(screen.getByLabelText("Edit filter"));

--- a/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/FilterGroup.test.tsx
+++ b/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/FilterGroup.test.tsx
@@ -65,7 +65,11 @@ describe("filters", () => {
     await user.click(confirmButton);
 
     expect(editFilter).toHaveBeenCalledTimes(1);
-    expect(editFilter).toHaveBeenCalledWith("name", "newFilter", defaultFilter);
+    expect(editFilter).toHaveBeenCalledWith(
+      "expression",
+      "newFilter",
+      defaultFilter
+    );
   });
 
   it("should prevent the user from submitting an invalid filter", async () => {

--- a/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/index.tsx
+++ b/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/index.tsx
@@ -38,35 +38,35 @@ const FilterGroup: React.FC<FilterGroupProps> = ({
   filter,
 }) => {
   const { sendEvent } = useLogWindowAnalytics();
-  const { caseSensitive, matchType, name, visible } = filter;
+  const { caseSensitive, expression, matchType, visible } = filter;
 
-  const [newFilterName, setNewFilterName] = useState(name);
+  const [newFilterExpression, setNewFilterExpression] = useState(expression);
   const [isEditing, setIsEditing] = useState(false);
   const [isValid, setIsValid] = useState(true);
 
   useEffect(() => {
-    if (name) {
-      setIsValid(validateRegexp(name));
+    if (expression) {
+      setIsValid(validateRegexp(expression));
     }
-  }, [name]);
+  }, [expression]);
 
   const resetEditState = () => {
     setIsEditing(false);
-    setNewFilterName(name);
+    setNewFilterExpression(expression);
   };
 
   const handleSubmit = () => {
     if (isValid) {
-      editFilter("name", newFilterName, filter);
+      editFilter("expression", newFilterExpression, filter);
       resetEditState();
     }
   };
 
   const showTooltip = !isValid && !isEditing;
   const validationMessage =
-    newFilterName === ""
+    newFilterExpression === ""
       ? "Filter cannot be empty"
-      : `Invalid Regular Expression: ${getRegexpError(newFilterName)}`;
+      : `Invalid Regular Expression: ${getRegexpError(newFilterExpression)}`;
 
   return (
     <Accordion
@@ -83,7 +83,7 @@ const FilterGroup: React.FC<FilterGroupProps> = ({
               <Error>{validationMessage}</Error>
             </IconWithTooltip>
           )}
-          <TextEllipsis>{name}</TextEllipsis>
+          <TextEllipsis>{expression}</TextEllipsis>
         </>
       }
       titleTag={AccordionTitle}
@@ -125,7 +125,7 @@ const FilterGroup: React.FC<FilterGroupProps> = ({
               aria-label="Delete filter"
               onClick={(e) => {
                 e.stopPropagation();
-                deleteFilter(name);
+                deleteFilter(expression);
               }}
               title="Delete filter"
             >
@@ -145,7 +145,7 @@ const FilterGroup: React.FC<FilterGroupProps> = ({
               data-cy="edit-filter-name"
               errorMessage={isValid ? "" : validationMessage}
               onChange={(e) => {
-                setNewFilterName(e.target.value);
+                setNewFilterExpression(e.target.value);
                 setIsValid(
                   validateRegexp(e.target.value) && e.target.value !== ""
                 );
@@ -156,7 +156,7 @@ const FilterGroup: React.FC<FilterGroupProps> = ({
               spellCheck={false}
               state={isValid ? "none" : "error"}
               type="text"
-              value={newFilterName}
+              value={newFilterExpression}
             />
             <ButtonWrapper>
               <Button onClick={() => resetEditState()} size="xsmall">
@@ -173,7 +173,7 @@ const FilterGroup: React.FC<FilterGroupProps> = ({
             </ButtonWrapper>
           </>
         ) : (
-          <StyledBody>{name}</StyledBody>
+          <StyledBody>{expression}</StyledBody>
         )}
 
         <StyledSegmentedControl

--- a/src/components/SidePanel/NavGroup/FilterNavGroup/index.tsx
+++ b/src/components/SidePanel/NavGroup/FilterNavGroup/index.tsx
@@ -25,14 +25,14 @@ const FilterNavGroup: React.FC<FilterNavGroupProps> = ({
   const [filters, setFilters] = useFilterParam();
   const [open, setOpen] = useState(false);
 
-  const deleteFilter = (filterName: string) => {
-    const newFilters = filters.filter((f) => f.name !== filterName);
+  const deleteFilter = (filterExpression: string) => {
+    const newFilters = filters.filter((f) => f.expression !== filterExpression);
     setFilters(newFilters);
     if (newFilters.length === 0) {
       clearExpandedLines();
     }
-    leaveBreadcrumb("delete-filter", { filterName }, "user");
-    sendEvent({ filterExpression: filterName, name: "Deleted Filter" });
+    leaveBreadcrumb("delete-filter", { filterExpression }, "user");
+    sendEvent({ filterExpression, name: "Deleted Filter" });
   };
 
   const editFilter = (
@@ -41,11 +41,16 @@ const FilterNavGroup: React.FC<FilterNavGroupProps> = ({
     filter: Filter
   ) => {
     // Duplicate filters are not allowed.
-    if (fieldName === "name" && filters.some((f) => f.name === fieldValue)) {
+    if (
+      fieldName === "expression" &&
+      filters.some((f) => f.expression === fieldValue)
+    ) {
       return;
     }
     const newFilters = [...filters];
-    const idxToReplace = newFilters.findIndex((f) => f.name === filter.name);
+    const idxToReplace = newFilters.findIndex(
+      (f) => f.expression === filter.expression
+    );
     newFilters[idxToReplace] = {
       ...filter,
       [fieldName]: fieldValue,
@@ -53,7 +58,7 @@ const FilterNavGroup: React.FC<FilterNavGroupProps> = ({
     setFilters(newFilters);
     leaveBreadcrumb(
       "edit-filter",
-      { fieldName, fieldValue, filterName: filter.name },
+      { fieldName, fieldValue, filterExpression: filter.expression },
       "user"
     );
     sendEvent({
@@ -83,7 +88,10 @@ const FilterNavGroup: React.FC<FilterNavGroupProps> = ({
         navGroupTitle="Filters"
       >
         {filters.map((filter) => (
-          <FilterWrapper key={filter.name} data-cy={`filter-${filter.name}`}>
+          <FilterWrapper
+            key={filter.expression}
+            data-cy={`filter-${filter.expression}`}
+          >
             <FilterGroup
               deleteFilter={deleteFilter}
               editFilter={editFilter}

--- a/src/hooks/useFilterParam/useFilterParam.test.tsx
+++ b/src/hooks/useFilterParam/useFilterParam.test.tsx
@@ -21,8 +21,8 @@ describe("useFilterParam", () => {
     const newFilter = [
       {
         caseSensitive: CaseSensitivity.Insensitive,
+        expression: "newfilter",
         matchType: MatchType.Exact,
-        name: "newfilter",
         visible: true,
       },
     ];
@@ -54,14 +54,14 @@ describe("useFilterParam", () => {
     expect(result.current.filters).toStrictEqual([
       {
         caseSensitive: CaseSensitivity.Insensitive,
+        expression: "failed",
         matchType: MatchType.Exact,
-        name: "failed",
         visible: true,
       },
       {
         caseSensitive: CaseSensitivity.Sensitive,
+        expression: "passed",
         matchType: MatchType.Exact,
-        name: "passed",
         visible: true,
       },
     ]);
@@ -82,14 +82,14 @@ describe("useFilterParam", () => {
       result.current.setFilters([
         {
           caseSensitive: CaseSensitivity.Insensitive,
+          expression: "something,else",
           matchType: MatchType.Exact,
-          name: "something,else",
           visible: true,
         },
         {
           caseSensitive: CaseSensitivity.Insensitive,
+          expression: "failed",
           matchType: MatchType.Exact,
-          name: "failed",
           visible: true,
         },
       ]);
@@ -114,14 +114,14 @@ describe("useFilterParam", () => {
     expect(result.current.filters).toStrictEqual([
       {
         caseSensitive: CaseSensitivity.Insensitive,
+        expression: "something,else",
         matchType: MatchType.Exact,
-        name: "something,else",
         visible: true,
       },
       {
         caseSensitive: CaseSensitivity.Insensitive,
+        expression: "failed",
         matchType: MatchType.Exact,
-        name: "failed",
         visible: true,
       },
     ]);
@@ -137,8 +137,8 @@ describe("useFilterParam", () => {
     expect(result.current.filters).toStrictEqual([
       {
         caseSensitive: CaseSensitivity.Insensitive,
+        expression: "1234567890123456789",
         matchType: MatchType.Exact,
-        name: "1234567890123456789",
         visible: true,
       },
     ]);

--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -7,7 +7,7 @@ type ProcessedLogLine = number | number[];
 type ProcessedLogLines = ProcessedLogLine[];
 
 type Filter = {
-  name: string;
+  expression: string;
   visible: boolean;
   caseSensitive: CaseSensitivity;
   matchType: MatchType;

--- a/src/utils/matchingLines/index.ts
+++ b/src/utils/matchingLines/index.ts
@@ -15,11 +15,11 @@ export const constructRegexToMatch = (visibleFilters: Filters) => {
     if (f.caseSensitive === CaseSensitivity.Sensitive) {
       regexToMatch.push({
         isMatch,
-        regex: new RegExp(f.name),
+        regex: new RegExp(f.expression),
       });
     } else {
       try {
-        const regex = new RegExp(f.name, "i");
+        const regex = new RegExp(f.expression, "i");
         regexToMatch.push({
           isMatch,
           regex,
@@ -27,7 +27,7 @@ export const constructRegexToMatch = (visibleFilters: Filters) => {
       } catch (e) {
         // If we get an error here, it means the regex is invalid and got past the validation step. We should report this error.
         reportError({
-          message: `The regex "${f.name}" is invalid`,
+          message: `The regex "${f.expression}" is invalid`,
           metadata: e,
           name: "Invalid Regex",
         }).severe();

--- a/src/utils/matchingLines/matchingLines.test.ts
+++ b/src/utils/matchingLines/matchingLines.test.ts
@@ -4,29 +4,29 @@ import { constructRegexToMatch, getMatchingLines, matchesFilters } from ".";
 /**
  * Helper function for constructing a Filter object.
  * @param filter - the filter object to construct
- * @param filter.name - the name of the filter
+ * @param filter.expression - the regular expression of the filter
  * @param filter.caseSensitive - whether or not the filter is case sensitive
  * @param filter.matchType - the match type of the filter (exact, inverse)
  * @param filter.visible - whether or not the filter is visible
  * @returns a Filter object
  */
 const makeFilter = (filter: {
-  name: string;
+  expression: string;
   caseSensitive?: CaseSensitivity;
   matchType?: MatchType;
   visible?: boolean;
 }) => {
   const {
     caseSensitive = CaseSensitivity.Insensitive,
+    expression,
     matchType = MatchType.Exact,
-    name,
     visible = true,
   } = filter;
 
   return {
     caseSensitive,
+    expression,
     matchType,
-    name,
     visible,
   };
 };
@@ -46,9 +46,9 @@ describe("constructRegexToMatch", () => {
   it("properly constructs case sensitive filters", () => {
     const filter1 = makeFilter({
       caseSensitive: CaseSensitivity.Sensitive,
-      name: "filter1",
+      expression: "filter1",
     });
-    const filter2 = makeFilter({ name: "filter2" });
+    const filter2 = makeFilter({ expression: "filter2" });
     expect(constructRegexToMatch([filter1, filter2])).toStrictEqual([
       { isMatch: true, regex: /filter1/ },
       { isMatch: true, regex: /filter2/i },
@@ -57,10 +57,10 @@ describe("constructRegexToMatch", () => {
 
   it("properly constructs inverse match filters", () => {
     const filter1 = makeFilter({
+      expression: "filter1",
       matchType: MatchType.Inverse,
-      name: "filter1",
     });
-    const filter2 = makeFilter({ name: "filter2" });
+    const filter2 = makeFilter({ expression: "filter2" });
     expect(constructRegexToMatch([filter1, filter2])).toStrictEqual([
       { isMatch: false, regex: /filter1/i },
       { isMatch: true, regex: /filter2/i },
@@ -203,8 +203,8 @@ describe("getMatchingLines", () => {
   });
 
   it("returns undefined if there are no visible filters", () => {
-    const filter1 = makeFilter({ name: "starting", visible: false });
-    const filter2 = makeFilter({ name: "mongod", visible: false });
+    const filter1 = makeFilter({ expression: "starting", visible: false });
+    const filter2 = makeFilter({ expression: "mongod", visible: false });
     expect(
       getMatchingLines(logLines, [filter1, filter2], FilterLogic.And)
     ).toBeUndefined();
@@ -213,9 +213,9 @@ describe("getMatchingLines", () => {
   it("returns an empty set if there are no lines that satisfy the filter", () => {
     const filter1 = makeFilter({
       caseSensitive: CaseSensitivity.Sensitive,
-      name: "starting",
+      expression: "starting",
     });
-    const filter2 = makeFilter({ name: "mongod" });
+    const filter2 = makeFilter({ expression: "mongod" });
     expect(
       getMatchingLines(logLines, [filter1, filter2], FilterLogic.And)
     ).toStrictEqual(new Set([]));
@@ -223,9 +223,9 @@ describe("getMatchingLines", () => {
 
   it("returns correct set of numbers given applied filters", () => {
     const filter1 = makeFilter({
-      name: "starting",
+      expression: "starting",
     });
-    const filter2 = makeFilter({ name: "mongod" });
+    const filter2 = makeFilter({ expression: "mongod" });
     expect(
       getMatchingLines(logLines, [filter1, filter2], FilterLogic.And)
     ).toStrictEqual(new Set([1, 4, 7]));
@@ -233,9 +233,9 @@ describe("getMatchingLines", () => {
 
   it("only uses visible filters when looking for matches", () => {
     const filter1 = makeFilter({
-      name: "starting",
+      expression: "starting",
     });
-    const filter2 = makeFilter({ name: "mongod", visible: false });
+    const filter2 = makeFilter({ expression: "mongod", visible: false });
     expect(
       getMatchingLines(logLines, [filter1, filter2], FilterLogic.And)
     ).toStrictEqual(new Set([0, 1, 4, 7]));

--- a/src/utils/query-string/index.ts
+++ b/src/utils/query-string/index.ts
@@ -38,12 +38,12 @@ export const parseFilters = (filters: string[]): Filters => {
         : CaseSensitivity.Insensitive;
     const matchType =
       filter.charAt(2) === "1" ? MatchType.Inverse : MatchType.Exact;
-    const name = filter.substring(3);
-    const decodedFilterName = decodeURIComponent(name);
+    const expression = filter.substring(3);
+    const decodedFilterExpression = decodeURIComponent(expression);
     return {
       caseSensitive,
+      expression: decodedFilterExpression,
       matchType,
-      name: decodedFilterName,
       visible,
     };
   });
@@ -55,6 +55,6 @@ export const stringifyFilters = (filters: Filters): string[] =>
     const visible = f.visible ? 1 : 0;
     const caseSensitive = f.caseSensitive === CaseSensitivity.Sensitive ? 1 : 0;
     const matchType = f.matchType === MatchType.Inverse ? 1 : 0;
-    const encodedFilterName = encodeURIComponent(f.name);
+    const encodedFilterName = encodeURIComponent(f.expression);
     return `${visible}${caseSensitive}${matchType}${encodedFilterName}`;
   });

--- a/src/utils/query-string/query-string.test.ts
+++ b/src/utils/query-string/query-string.test.ts
@@ -16,8 +16,8 @@ describe("filters", () => {
         stringifyFilters([
           {
             caseSensitive: CaseSensitivity.Insensitive,
+            expression: "hello-i-am-a-filter",
             matchType: MatchType.Exact,
-            name: "hello-i-am-a-filter",
             visible: true,
           },
         ])
@@ -28,20 +28,20 @@ describe("filters", () => {
         stringifyFilters([
           {
             caseSensitive: CaseSensitivity.Sensitive,
+            expression: "passed",
             matchType: MatchType.Inverse,
-            name: "passed",
             visible: false,
           },
           {
             caseSensitive: CaseSensitivity.Insensitive,
+            expression: "failed",
             matchType: MatchType.Inverse,
-            name: "failed",
             visible: true,
           },
           {
             caseSensitive: CaseSensitivity.Sensitive,
+            expression: "running",
             matchType: MatchType.Exact,
-            name: "running",
             visible: false,
           },
         ])
@@ -52,8 +52,8 @@ describe("filters", () => {
         stringifyFilters([
           {
             caseSensitive: CaseSensitivity.Insensitive,
+            expression: "ran in d{3,}",
             matchType: MatchType.Exact,
-            name: "ran in d{3,}",
             visible: true,
           },
         ])
@@ -68,8 +68,8 @@ describe("filters", () => {
       expect(parseFilters(["100hello-i-am-a-filter"])).toStrictEqual([
         {
           caseSensitive: CaseSensitivity.Insensitive,
+          expression: "hello-i-am-a-filter",
           matchType: MatchType.Exact,
-          name: "hello-i-am-a-filter",
           visible: true,
         },
       ]);
@@ -78,8 +78,8 @@ describe("filters", () => {
       expect(parseFilters(["10012345"])).toStrictEqual([
         {
           caseSensitive: CaseSensitivity.Insensitive,
+          expression: "12345",
           matchType: MatchType.Exact,
-          name: "12345",
           visible: true,
         },
       ]);
@@ -88,8 +88,8 @@ describe("filters", () => {
       expect(parseFilters(["100ran%20in%20d%7B3%2C%7D"])).toStrictEqual([
         {
           caseSensitive: CaseSensitivity.Insensitive,
+          expression: "ran in d{3,}",
           matchType: MatchType.Exact,
-          name: "ran in d{3,}",
           visible: true,
         },
       ]);
@@ -100,20 +100,20 @@ describe("filters", () => {
       ).toStrictEqual([
         {
           caseSensitive: CaseSensitivity.Sensitive,
+          expression: "passed",
           matchType: MatchType.Inverse,
-          name: "passed",
           visible: false,
         },
         {
           caseSensitive: CaseSensitivity.Insensitive,
+          expression: "failed",
           matchType: MatchType.Inverse,
-          name: "failed",
           visible: true,
         },
         {
           caseSensitive: CaseSensitivity.Sensitive,
+          expression: "running",
           matchType: MatchType.Exact,
-          name: "running",
           visible: false,
         },
       ]);


### PR DESCRIPTION
EVG-20176

### Description 
Renames the usage of the word "name" to "expression" in the context of Filters. This should free up that variable for when we start creating named filters.
### Testing 
Existing tests should suffice
