### PR TITLE
EVG-20974: Downgrade graphql dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@leafygreen-ui/tooltip": "10.0.10",
     "@leafygreen-ui/typography": "16.5.0",
     "ansi_up": "5.1.0",
-    "graphql": "16.8.1",
+    "graphql": "16.6.0",
     "html-react-parser": "3.0.6",
     "js-cookie": "3.0.5",
     "linkify-html": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9619,10 +9619,10 @@ graphql-ws@^5.14.0:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.14.0.tgz#766f249f3974fc2c48fae0d1fb20c2c4c79cd591"
   integrity sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==
 
-graphql@16.8.1:
-  version "16.8.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
-  integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==
+graphql@16.6.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 gunzip-maybe@^1.4.2:
   version "1.4.2"


### PR DESCRIPTION
EVG-20974

### Description 
<!-- Add description, context, thought process, etc -->
- `yarn dev` is broken locally due to [this syntax error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Missing_name_after_dot_operator?utm_source=mozilla&utm_medium=firefox-console-errors&utm_campaign=default) included in the graphql package. Reverting the upgrade in https://github.com/evergreen-ci/parsley/pull/386 fixes it.
- I do not know why this package works fine in Spruce 🤔 but would rather figure that out separately

### Testing 
<!-- Add a description of how you tested it -->
- `yarn dev` runs locally