### PR TITLE
EVG-21000 Move deploy to prod to ubuntu2204 large

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -521,10 +521,6 @@ buildvariants:
       - name: test
       - name: snapshots
       - name: check_codegen
-      - name: deploy-prod
-        git_tag_only: true
-        patchable: false
-        priority: 100
 
   - name: ubuntu2204-large
     display_name: Ubuntu 22.04 (large)
@@ -541,6 +537,10 @@ buildvariants:
       - name: e2e_test
       - name: compile
       - name: storybook
+      - name: deploy-prod
+        git_tag_only: true
+        patchable: false
+        priority: 100
 
 pre:
   - func: get-project


### PR DESCRIPTION
EVG-21000

### Description 
The [deploy task](https://spruce.mongodb.com/task/parsley_ubuntu2204_small_deploy_prod__v1.0.112_23_10_02_15_37_26) started OOMing in the ubuntu small distro so it likely needs to be on a bigger distro with more memory. 


