### PR TITLE
EVG-21093 Use correct content_type type for logkeeper logs

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -432,7 +432,7 @@ functions:
       local_file: parsley/logkeeper/logkeeperapp.log
       remote_file: parsley/${task_id}/${execution}/logkeeperapp.log
       bucket: mciuploads
-      content_type: text/html
+      content_type: text/plain
       permissions: public-read
 
   seed-logkeeper:


### PR DESCRIPTION
EVG-21093

### Description 
Noticed logkeeper logs were being uploaded with the wrong mime type

