### PR TITLE
DEVPROD-1717 upgrade mongo to 7.0

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -360,7 +360,7 @@ functions:
       params:
         env:
           gobin: ${goroot}/bin/go
-          MONGODB_URL: ${mongodb_url_60}
+          MONGODB_URL: ${mongodb_url_70}
           MONGODB_DECOMPRESS: ${decompress}
         working_dir: parsley/evergreen
         command: make get-mongodb
@@ -506,8 +506,8 @@ buildvariants:
   - name: ubuntu2204-small
     display_name: Ubuntu 22.04 (small)
     expansions:
-      mongodb_url_60: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.6.tgz
-      mongosh_url: https://downloads.mongodb.com/compass/mongosh-1.9.0-linux-x64.tgz
+      mongodb_url_70: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.2.tgz
+      mongosh_url: https://downloads.mongodb.com/compass/mongosh-2.0.2-linux-x64.tgz
       node_version: 16.17.0
     run_on:
       - ubuntu2204-small
@@ -523,8 +523,8 @@ buildvariants:
   - name: ubuntu2204-large
     display_name: Ubuntu 22.04 (large)
     expansions:
-      mongodb_url_60: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.6.tgz
-      mongosh_url: https://downloads.mongodb.com/compass/mongosh-1.9.0-linux-x64.tgz
+      mongodb_url_70: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.2.tgz
+      mongosh_url: https://downloads.mongodb.com/compass/mongosh-2.0.2-linux-x64.tgz
       node_version: 16.17.0
     run_on:
       - ubuntu2204-large


### PR DESCRIPTION
[DEVPROD-1717](https://jira.mongodb.org/browse/DEVPROD-1717)

### Description 
Upgrade the db to 7.0 in tests in advance of upgrading the db itself. Upgrade mongosh while we're at it.

### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/7198
