### PR TITLE
DEVPROD-2232 Log download error at lower severity

### DIFF
--- a/src/hooks/useLogDownloader/index.ts
+++ b/src/hooks/useLogDownloader/index.ts
@@ -107,10 +107,15 @@ const useLogDownloader = (
         .catch((err: Error) => {
           leaveBreadcrumb(
             "useLogDownloader",
-            { err, url },
+            {
+              duration: Date.now() - timeStart,
+              err,
+              fileSize: getFileSize(),
+              url,
+            },
             SentryBreadcrumb.Error
           );
-          reportError(err).severe();
+          reportError(err).warning();
           setError(err.message);
           sendEvent({
             duration: Date.now() - timeStart,


### PR DESCRIPTION
DEVPROD-2232

### Description 
Since these alerts have been pretty noisy, let's log them as a warning and follow up by adjusting the alerting criteria in sentry in case they spike.

