### PR TITLE
Revert "DEVPROD-929: Use task log links from API"

### DIFF
--- a/config/jest/setupTests.ts
+++ b/config/jest/setupTests.ts
@@ -4,7 +4,6 @@ import "@testing-library/jest-dom/extend-expect";
 // The following two variables are dummy values used in auth.test.tsx.
 process.env.REACT_APP_EVERGREEN_URL = "test-evergreen.com";
 process.env.REACT_APP_GRAPHQL_URL = "test-graphql.com";
-process.env.REACT_APP_LOBSTER_URL = "test-lobster.com";
 
 if (process.env.CI) {
   // Avoid printing debug statements when running tests.

--- a/cypress/integration/routes.ts
+++ b/cypress/integration/routes.ts
@@ -17,11 +17,7 @@ describe("Parsley Routes", () => {
   it("should show error toast when visiting a task log page of an invalid task", () => {
     const logLink = "/evergreen/invalid-task-id/0/task";
     cy.visit(logLink);
-    cy.validateToast(
-      "error",
-      "Log URL not specified, unable to download.",
-      true
-    );
+    cy.validateToast("error", "Network response was not ok (404)", true);
   });
   it("should load test results when visiting a test result page", () => {
     const logLink =

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1675,6 +1675,7 @@ export type Project = {
   repo: Scalars["String"]["output"];
   repoRefId: Scalars["String"]["output"];
   repotrackerDisabled?: Maybe<Scalars["Boolean"]["output"]>;
+  repotrackerError?: Maybe<RepotrackerError>;
   restricted?: Maybe<Scalars["Boolean"]["output"]>;
   spawnHostScriptPath: Scalars["String"]["output"];
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -2203,6 +2204,13 @@ export type RepoWorkstationConfig = {
   __typename?: "RepoWorkstationConfig";
   gitClone: Scalars["Boolean"]["output"];
   setupCommands?: Maybe<Array<WorkstationSetupCommand>>;
+};
+
+export type RepotrackerError = {
+  __typename?: "RepotrackerError";
+  exists: Scalars["Boolean"]["output"];
+  invalidRevision: Scalars["String"]["output"];
+  mergeBaseRevision: Scalars["String"]["output"];
 };
 
 export enum RequiredStatus {
@@ -2928,6 +2936,7 @@ export type Version = {
   __typename?: "Version";
   activated?: Maybe<Scalars["Boolean"]["output"]>;
   author: Scalars["String"]["output"];
+  authorEmail: Scalars["String"]["output"];
   baseTaskStatuses: Array<Scalars["String"]["output"]>;
   baseVersion?: Maybe<Version>;
   branch: Scalars["String"]["output"];

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1675,7 +1675,6 @@ export type Project = {
   repo: Scalars["String"]["output"];
   repoRefId: Scalars["String"]["output"];
   repotrackerDisabled?: Maybe<Scalars["Boolean"]["output"]>;
-  repotrackerError?: Maybe<RepotrackerError>;
   restricted?: Maybe<Scalars["Boolean"]["output"]>;
   spawnHostScriptPath: Scalars["String"]["output"];
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -2204,13 +2203,6 @@ export type RepoWorkstationConfig = {
   __typename?: "RepoWorkstationConfig";
   gitClone: Scalars["Boolean"]["output"];
   setupCommands?: Maybe<Array<WorkstationSetupCommand>>;
-};
-
-export type RepotrackerError = {
-  __typename?: "RepotrackerError";
-  exists: Scalars["Boolean"]["output"];
-  invalidRevision: Scalars["String"]["output"];
-  mergeBaseRevision: Scalars["String"]["output"];
 };
 
 export enum RequiredStatus {
@@ -2936,7 +2928,6 @@ export type Version = {
   __typename?: "Version";
   activated?: Maybe<Scalars["Boolean"]["output"]>;
   author: Scalars["String"]["output"];
-  authorEmail: Scalars["String"]["output"];
   baseTaskStatuses: Array<Scalars["String"]["output"]>;
   baseVersion?: Maybe<Version>;
   branch: Scalars["String"]["output"];
@@ -3174,13 +3165,6 @@ export type TaskQuery = {
     id: string;
     patchNumber?: number | null;
     status: string;
-    logs: {
-      __typename?: "TaskLogLinks";
-      agentLogLink?: string | null;
-      allLogLink?: string | null;
-      systemLogLink?: string | null;
-      taskLogLink?: string | null;
-    };
     versionMetadata: {
       __typename?: "Version";
       id: string;

--- a/src/gql/queries/get-task.graphql
+++ b/src/gql/queries/get-task.graphql
@@ -3,11 +3,5 @@
 query Task($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
     ...BaseTask
-    logs {
-      agentLogLink
-      allLogLink
-      systemLogLink
-      taskLogLink
-    }
   }
 }

--- a/src/hooks/useLogDownloader/index.ts
+++ b/src/hooks/useLogDownloader/index.ts
@@ -17,35 +17,24 @@ import {
 import { fetchLogFile } from "utils/fetchLogFile";
 import { getBytesAsString } from "utils/string";
 
-type UseLogDownloader = {
-  downloadSizeLimit?: number;
-  isLoadingEvergreen?: boolean;
-  logType: LogTypes;
-  url: string;
-};
-
 /**
  * `useLogDownloader` is a custom hook that downloads a log file from a given URL.
  * It uses a fetch stream to download the log file and splits the log file into an array of strings.
  * Each string is split based on the newline character.
- * @param props - hook params object
- * @param props.url - the url to fetch
- * @param props.logType - the type of log file to download
- * @param props.downloadSizeLimit - the maximum size of the log file to download
- * @param props.isLoadingEvergreen - whether a GraphQL query is i
-n process to fetch the task or test.
+ * @param url - the url to fetch
+ * @param logType - the type of log file to download
+ * @param downloadSizeLimit - the maximum size of the log file to download
  * @returns an object with the following properties:
  * - isLoading: a boolean that is true while the log is being downloaded
  * - data: the log file as an array of strings
  * - error: an error message if the download fails
  * - fileSize: the size of the log file in bytes
  */
-const useLogDownloader = ({
-  downloadSizeLimit = LOG_FILE_SIZE_LIMIT,
-  isLoadingEvergreen = false,
-  logType,
-  url,
-}: UseLogDownloader) => {
+const useLogDownloader = (
+  url: string,
+  logType: LogTypes,
+  downloadSizeLimit: number = LOG_FILE_SIZE_LIMIT
+) => {
   const [data, setData] = useState<string[] | undefined>();
   const [error, setError] = useState<string | undefined>();
   const [fileSize, setFileSize, getFileSize] = useStateRef<number>(0);
@@ -153,9 +142,6 @@ const useLogDownloader = ({
           });
           setIsLoading(false);
         });
-    } else if (!url && !isLoadingEvergreen) {
-      setError("Log URL not specified, unable to download.");
-      setIsLoading(false);
     }
 
     return () => {
@@ -163,7 +149,7 @@ const useLogDownloader = ({
       abortController.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoadingEvergreen, url]);
+  }, [url]);
   return { data, error, fileSize, isLoading };
 };
 

--- a/src/hooks/useLogDownloader/useLogDownloader.test.ts
+++ b/src/hooks/useLogDownloader/useLogDownloader.test.ts
@@ -36,7 +36,7 @@ describe("useLogDownloader", () => {
     // RenderFakeToastContext is a mock of the ToastContext
     RenderFakeToastContext();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useLogDownloader({ logType: LogTypes.RESMOKE_LOGS, url: API_URL })
+      useLogDownloader(API_URL, LogTypes.RESMOKE_LOGS)
     );
     expect(result.current.isLoading).toBe(true);
     await waitForNextUpdate();
@@ -56,7 +56,7 @@ describe("useLogDownloader", () => {
     // RenderFakeToastContext is a mock of the ToastContext
     RenderFakeToastContext();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useLogDownloader({ logType: LogTypes.EVERGREEN_TASK_LOGS, url: API_URL })
+      useLogDownloader(API_URL, LogTypes.EVERGREEN_TASK_LOGS)
     );
     expect(result.current.isLoading).toBe(true);
     await waitForNextUpdate();
@@ -75,7 +75,7 @@ describe("useLogDownloader", () => {
     // RenderFakeToastContext is a mock of the ToastContext
     RenderFakeToastContext();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useLogDownloader({ logType: LogTypes.RESMOKE_LOGS, url: API_URL })
+      useLogDownloader(API_URL, LogTypes.RESMOKE_LOGS)
     );
     expect(result.current.isLoading).toBe(true);
     expect(result.current.fileSize).toBe(0);
@@ -95,7 +95,7 @@ describe("useLogDownloader", () => {
     // RenderFakeToastContext is a mock of the ToastContext
     RenderFakeToastContext();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useLogDownloader({ logType: LogTypes.RESMOKE_LOGS, url: API_URL })
+      useLogDownloader(API_URL, LogTypes.RESMOKE_LOGS)
     );
     expect(result.current.isLoading).toBe(true);
     await waitForNextUpdate();
@@ -115,11 +115,7 @@ describe("useLogDownloader", () => {
     // RenderFakeToastContext is a mock of the ToastContext
     const { dispatchToast } = RenderFakeToastContext();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useLogDownloader({
-        downloadSizeLimit: 5,
-        logType: LogTypes.RESMOKE_LOGS,
-        url: API_URL,
-      })
+      useLogDownloader(API_URL, LogTypes.RESMOKE_LOGS, 5)
     );
     expect(result.current.isLoading).toBe(true);
     await waitForNextUpdate();
@@ -145,7 +141,7 @@ describe("useLogDownloader", () => {
     // RenderFakeToastContext is a mock of the ToastContext
     const { dispatchToast } = RenderFakeToastContext();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useLogDownloader({ logType: LogTypes.RESMOKE_LOGS, url: API_URL })
+      useLogDownloader(API_URL, LogTypes.RESMOKE_LOGS)
     );
     expect(result.current.isLoading).toBe(true);
     await waitForNextUpdate();

--- a/src/hooks/useTaskQuery/index.ts
+++ b/src/hooks/useTaskQuery/index.ts
@@ -1,10 +1,8 @@
 import { useQuery } from "@apollo/client";
 import { LogTypes } from "constants/enums";
 import {
-  BaseTaskFragment,
   LogkeeperTaskQuery,
   LogkeeperTaskQueryVariables,
-  TaskLogLinks,
   TaskQuery,
   TaskQueryVariables,
   TaskTestResult,
@@ -19,15 +17,7 @@ interface UseTaskQueryProps {
 }
 
 type UseTaskQueryReturnType = {
-  task:
-    | (BaseTaskFragment & {
-        logs?: TaskLogLinks;
-        tests?: {
-          testResults?: TaskTestResult["testResults"];
-        };
-      })
-    | undefined
-    | null;
+  task: (TaskQuery["task"] & { tests?: TaskTestResult }) | undefined | null;
   loading: boolean;
 };
 

--- a/src/pages/LogView/LoadingPage/index.tsx
+++ b/src/pages/LogView/LoadingPage/index.tsx
@@ -39,7 +39,7 @@ const LoadingPage: React.FC<LoadingPageProps> = ({ logType }) => {
     htmlLogURL,
     jobLogsURL,
     legacyJobLogsURL,
-    loading: isLoadingEvergreen,
+    loading: isLoadingTest,
     lobsterURL,
     rawLogURL,
   } = useResolveLogURL({
@@ -65,7 +65,7 @@ const LoadingPage: React.FC<LoadingPageProps> = ({ logType }) => {
     error,
     fileSize,
     isLoading: isLoadingLog,
-  } = useLogDownloader({ isLoadingEvergreen, logType, url: downloadURL });
+  } = useLogDownloader(downloadURL, logType);
 
   useEffect(() => {
     if (data && !isLoadingLogkeeperMetadata) {
@@ -113,7 +113,7 @@ const LoadingPage: React.FC<LoadingPageProps> = ({ logType }) => {
     logkeeperMetadata?.execution,
   ]);
 
-  if (isLoadingLog || isLoadingEvergreen) {
+  if (isLoadingLog || isLoadingTest) {
     return (
       <Container>
         <LoadingBarContainer>

--- a/src/pages/LogView/LoadingPage/useResolveLogURL.test.tsx
+++ b/src/pages/LogView/LoadingPage/useResolveLogURL.test.tsx
@@ -129,7 +129,6 @@ describe("useResolveLogURL", () => {
       }
     );
     await waitForNextUpdate();
-    await waitForNextUpdate();
     expect(result.current).toMatchObject({
       downloadURL:
         "test-evergreen.com/task_file_raw/a-task-id/0/a%20file%20name.some%2Fcrazy%2Fpath",

--- a/src/pages/LogView/LoadingPage/useResolveLogURL.test.tsx
+++ b/src/pages/LogView/LoadingPage/useResolveLogURL.test.tsx
@@ -4,19 +4,17 @@ import { LogTypes } from "constants/enums";
 import {
   TaskFilesQuery,
   TaskFilesQueryVariables,
-  TaskQuery,
-  TaskQueryVariables,
   TestLogUrlQuery,
   TestLogUrlQueryVariables,
 } from "gql/generated/types";
-import { GET_TASK, GET_TEST_LOG_URL, TASK_FILES } from "gql/queries";
+import { GET_TEST_LOG_URL, TASK_FILES } from "gql/queries";
 import { ApolloMock } from "types/gql";
 import { useResolveLogURL } from "./useResolveLogURL";
 
 describe("useResolveLogURL", () => {
   it("resolves test log URLs from GraphQL resolver when data is available", async () => {
     const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-      <MockedProvider mocks={[evergreenTaskMock, getExistingTestLogURLMock]}>
+      <MockedProvider mocks={[getExistingTestLogURLMock]}>
         {children}
       </MockedProvider>
     );
@@ -53,48 +51,9 @@ describe("useResolveLogURL", () => {
     });
   });
 
-  it("resolves task log URLs from GraphQL resolver when data is available", async () => {
-    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-      <MockedProvider mocks={[evergreenTaskMock, getExistingTestLogURLMock]}>
-        {children}
-      </MockedProvider>
-    );
-    const { result, waitForNextUpdate } = renderHook(
-      () =>
-        useResolveLogURL({
-          execution: "0",
-          logType: "EVERGREEN_TASK_LOGS",
-          origin: "agent",
-          taskID: "a-task-id",
-        }),
-      {
-        wrapper,
-      }
-    );
-    expect(result.current).toMatchObject({
-      downloadURL: "",
-      htmlLogURL: "",
-      jobLogsURL: "",
-      legacyJobLogsURL: "",
-      loading: true,
-      lobsterURL: "",
-      rawLogURL: "",
-    });
-    await waitForNextUpdate();
-    expect(result.current).toMatchObject({
-      downloadURL: "agent-link.com?priority=true&text=true&type=E",
-      htmlLogURL: "agent-link.com?text=false&type=E",
-      jobLogsURL: "",
-      legacyJobLogsURL: "",
-      loading: false,
-      lobsterURL: "test-lobster.com/evergreen/task/a-task-id/0/agent",
-      rawLogURL: "agent-link.com?text=true&type=E",
-    });
-  });
-
   it("generates test log URLs without GraphQL data when GraphQL data is empty", async () => {
     const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-      <MockedProvider mocks={[evergreenTaskMock, getEmptyTestLogURLMock]}>
+      <MockedProvider mocks={[getEmptyTestLogURLMock]}>
         {children}
       </MockedProvider>
     );
@@ -120,7 +79,7 @@ describe("useResolveLogURL", () => {
       legacyJobLogsURL: "",
       loading: false,
       lobsterURL:
-        "test-lobster.com/evergreen/test/a-task-id/0/a-test-name-that-doesnt-exist",
+        "undefined/evergreen/test/a-task-id/0/a-test-name-that-doesnt-exist",
       rawLogURL:
         "test-evergreen.com/test_log/a-task-id/0?test_name=a-test-name-that-doesnt-exist&text=true",
     });
@@ -128,9 +87,7 @@ describe("useResolveLogURL", () => {
 
   it("generates task file urls", async () => {
     const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-      <MockedProvider mocks={[evergreenTaskMock, getTaskFileURLMock]}>
-        {children}
-      </MockedProvider>
+      <MockedProvider mocks={[getTaskFileURLMock]}>{children}</MockedProvider>
     );
     const { result, waitForNextUpdate } = renderHook(
       () =>
@@ -155,12 +112,9 @@ describe("useResolveLogURL", () => {
       rawLogURL: "a-file-url",
     });
   });
-
   it("generates task file urls that are properly encoded", async () => {
     const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-      <MockedProvider mocks={[evergreenTaskMock, getTaskFileURLMock]}>
-        {children}
-      </MockedProvider>
+      <MockedProvider mocks={[getTaskFileURLMock]}>{children}</MockedProvider>
     );
     const { result, waitForNextUpdate } = renderHook(
       () =>
@@ -283,39 +237,3 @@ const getTaskFileURLMock: ApolloMock<TaskFilesQuery, TaskFilesQueryVariables> =
       },
     },
   };
-
-const evergreenTaskMock: ApolloMock<TaskQuery, TaskQueryVariables> = {
-  request: {
-    query: GET_TASK,
-    variables: {
-      execution: 0,
-      taskId: "a-task-id",
-    },
-  },
-  result: {
-    data: {
-      task: {
-        __typename: "Task",
-        displayName: "check_codegen",
-        execution: 0,
-        id: "a-task-id",
-        logs: {
-          agentLogLink: "agent-link.com?type=E",
-          allLogLink: "all-log-link.com?type=ALL",
-          systemLogLink: "system-log-link.com?type=S",
-          taskLogLink: "task-log-link.com?type=T",
-        },
-        patchNumber: 1,
-        status: "failed",
-        versionMetadata: {
-          __typename: "Version",
-          id: "spruce_d54e2c6ede60e004c48d3c4d996c59579c7bbd1f",
-          isPatch: false,
-          message: "v2.28.5",
-          projectIdentifier: "spruce",
-          revision: "d54e2c6ede60e004c48d3c4d996c59579c7bbd1f",
-        },
-      },
-    },
-  },
-};

--- a/src/pages/LogView/LoadingPage/useResolveLogURL.ts
+++ b/src/pages/LogView/LoadingPage/useResolveLogURL.ts
@@ -20,7 +20,6 @@ import {
   TestLogUrlQueryVariables,
 } from "gql/generated/types";
 import { GET_TEST_LOG_URL, TASK_FILES } from "gql/queries";
-import { useTaskQuery } from "hooks/useTaskQuery";
 
 interface UseResolveLogURLProps {
   buildID?: string;
@@ -72,13 +71,6 @@ export const useResolveLogURL = ({
   taskID,
   testID,
 }: UseResolveLogURLProps): LogURLs => {
-  const { loading: isLoadingTask, task } = useTaskQuery({
-    buildID,
-    execution,
-    logType: logType as LogTypes,
-    taskID,
-  });
-
   const { data: testData, loading: isLoadingTest } = useQuery<
     TestLogUrlQuery,
     TestLogUrlQueryVariables
@@ -150,17 +142,17 @@ export const useResolveLogURL = ({
       break;
     }
     case LogTypes.EVERGREEN_TASK_LOGS: {
-      if (!taskID || !origin || !execution || !task?.logs || isLoadingTask) {
+      if (!taskID || !execution || !origin) {
         break;
       }
-      downloadURL = getEvergreenTaskLogURL(task.logs, origin, {
+      downloadURL = getEvergreenTaskLogURL(taskID, execution, origin as any, {
         priority: true,
         text: true,
       });
-      rawLogURL = getEvergreenTaskLogURL(task.logs, origin, {
+      rawLogURL = getEvergreenTaskLogURL(taskID, execution, origin as any, {
         text: true,
       });
-      htmlLogURL = getEvergreenTaskLogURL(task.logs, origin, {
+      htmlLogURL = getEvergreenTaskLogURL(taskID, execution, origin as any, {
         text: false,
       });
       lobsterURL = getLobsterTaskURL(taskID, execution, origin);
@@ -197,7 +189,7 @@ export const useResolveLogURL = ({
     htmlLogURL,
     jobLogsURL,
     legacyJobLogsURL,
-    loading: isLoadingTest || isLoadingTask || isLoadingTaskFileData,
+    loading: isLoadingTest,
     lobsterURL,
     rawLogURL,
   };

--- a/src/test_data/task.ts
+++ b/src/test_data/task.ts
@@ -23,12 +23,6 @@ export const evergreenTaskMock: ApolloMock<TaskQuery, TaskQueryVariables> = {
         displayName: "check_codegen",
         execution: 0,
         id: "spruce_ubuntu1604_check_codegen_d54e2c6ede60e004c48d3c4d996c59579c7bbd1f_22_03_02_15_41_35",
-        logs: {
-          agentLogLink: "log-link.com?type=E",
-          allLogLink: "log-link.com?type=ALL",
-          systemLogLink: "log-link.com?type=S",
-          taskLogLink: "log-link.com?type=T",
-        },
         patchNumber: 1236,
         status: "failed",
         versionMetadata: {


### PR DESCRIPTION
Reverts evergreen-ci/parsley#431

Reverting due to spike in errors, see #evergreen-ops channel. Not quite sure what the problem is — maybe something with `abortController` which is only defined in production?