### PR TITLE
DEVPROD-2643: Remove useLogDownloader hook dependency

### DIFF
--- a/src/hooks/useLogDownloader/index.ts
+++ b/src/hooks/useLogDownloader/index.ts
@@ -163,7 +163,7 @@ const useLogDownloader = ({
       abortController.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoadingEvergreen, url]);
+  }, [url]);
   return { data, error, fileSize, isLoading };
 };
 


### PR DESCRIPTION
DEVPROD-2643

### Description 
<!-- Add description, context, thought process, etc -->
- Remove `useLogDownloader` dependency on `isEvergreenLoading`. This dependency caused the hook to run multiple times; when the bug was deployed to production you could observe multiple requests to Logkeeper. I think the subsequent request to Logkeeper also resulted in the first one being terminated, hence the "Incomplete log" warnings we saw earlier today.

### Testing 
<!-- Add a description of how you tested it -->
- Verified on beta that removing this dependency results in a single call to fetch the log. It's deployed to beta right now if you care to look!