### PR TITLE
DEVPROD-1904 Fix flaky test caused by racing assertions and Introduce realClick for clipboard events

### DIFF
--- a/cypress/integration/ansiLogs/ansi_logView.ts
+++ b/cypress/integration/ansiLogs/ansi_logView.ts
@@ -103,7 +103,7 @@ describe("Bookmarking and selecting lines", () => {
     const logLine297 =
       "[2022/03/02 17:05:21.050] running setup group because we have a new independent task";
 
-    cy.dataCy("details-button").click();
+    cy.toggleDetailsPanel(true);
     // Need to fire a real click here because the copy to clipboard
     cy.dataCy("jira-button").realClick();
     cy.window().then((win) => {

--- a/cypress/integration/ansiLogs/ansi_logView.ts
+++ b/cypress/integration/ansiLogs/ansi_logView.ts
@@ -106,13 +106,9 @@ describe("Bookmarking and selecting lines", () => {
     cy.toggleDetailsPanel(true);
     // Need to fire a real click here because the copy to clipboard
     cy.dataCy("jira-button").realClick();
-    cy.window().then((win) => {
-      win.navigator.clipboard.readText().then((text) => {
-        expect(text).to.eq(
-          `{noformat}\n${logLine0}\n...\n${logLine10}\n${logLine11}\n...\n${logLine297}\n{noformat}`
-        );
-      });
-    });
+    cy.assertValueCopiedToClipboard(
+      `{noformat}\n${logLine0}\n...\n${logLine10}\n${logLine11}\n...\n${logLine297}\n{noformat}`
+    );
   });
 
   it("should be able to clear bookmarks", () => {
@@ -230,13 +226,9 @@ describe("Sharing lines", () => {
     // Need to fire a real click here because the copy to clipboard
     cy.contains("Copy selected contents").realClick();
     cy.validateToast("success", "Copied 2 lines to clipboard", true);
-    cy.window().then((win) => {
-      win.navigator.clipboard.readText().then((text) => {
-        expect(text).to.eq(
-          `{noformat}\n[2022/03/02 17:01:58.587] Task logger initialized (agent version 2022-02-14 from 00a4c8f3e8e4559cc23e04a019b6d1725c40c3e5).\n...\n[2022/03/02 17:02:01.610] e391612 EVG-16049 Update spruce project page for admin only variables (#1114)\n[2022/03/02 17:02:01.610] 04a52b2 EVG-15959 Fix rerender method in test utils (#1118)\n...\n[2022/03/02 17:05:21.050] running setup group because we have a new independent task\n{noformat}`
-        );
-      });
-    });
+    cy.assertValueCopiedToClipboard(
+      `{noformat}\n[2022/03/02 17:01:58.587] Starting task spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12, execution 0.\n[2022/03/02 17:01:58.701] Running pre-task commands.\n{noformat}`
+    );
   });
   it("should be able to copy a link to the selected lines", () => {
     cy.dataCy("line-index-1").click();
@@ -246,13 +238,9 @@ describe("Sharing lines", () => {
     // Need to fire a real click here because the copy to clipboard
     cy.contains("Copy share link to selected lines").realClick();
     cy.validateToast("success", "Copied link to clipboard", true);
-    cy.window().then((win) => {
-      win.navigator.clipboard.readText().then((text) => {
-        expect(text).to.eq(
-          "http://localhost:4173/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task?bookmarks=0%2C297&selectedLineRange=L1-L2&shareLine=1"
-        );
-      });
-    });
+    cy.assertValueCopiedToClipboard(
+      "http://localhost:4173/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task?bookmarks=0%2C297&selectedLineRange=L1-L2&shareLine=1"
+    );
   });
   it("should be able to limit the search range to the selected lines", () => {
     cy.dataCy("line-index-1").click();

--- a/cypress/integration/ansiLogs/ansi_logView.ts
+++ b/cypress/integration/ansiLogs/ansi_logView.ts
@@ -104,7 +104,8 @@ describe("Bookmarking and selecting lines", () => {
       "[2022/03/02 17:05:21.050] running setup group because we have a new independent task";
 
     cy.dataCy("details-button").click();
-    cy.dataCy("jira-button").click();
+    // Need to fire a real click here because the copy to clipboard
+    cy.dataCy("jira-button").realClick();
     cy.window().then((win) => {
       win.navigator.clipboard.readText().then((text) => {
         expect(text).to.eq(
@@ -207,7 +208,7 @@ describe("Sharing lines", () => {
 
   beforeEach(() => {
     cy.visit(logLink);
-    cy.dataCy("line-index-1").should("be.visible");
+    cy.dataCy("line-index-1").should("exist").should("be.visible");
   });
 
   it("should present a share button with a menu when a line is selected", () => {
@@ -226,7 +227,8 @@ describe("Sharing lines", () => {
     cy.dataCy("line-index-2").click({ shiftKey: true });
     cy.dataCy("sharing-menu").should("be.visible");
     cy.contains("Copy selected contents").should("be.visible");
-    cy.contains("Copy selected contents").click();
+    // Need to fire a real click here because the copy to clipboard
+    cy.contains("Copy selected contents").realClick();
     cy.validateToast("success", "Copied 2 lines to clipboard", true);
     cy.window().then((win) => {
       win.navigator.clipboard.readText().then((text) => {
@@ -241,7 +243,8 @@ describe("Sharing lines", () => {
     cy.dataCy("line-index-2").click({ shiftKey: true });
     cy.dataCy("sharing-menu").should("be.visible");
     cy.contains("Copy share link to selected lines").should("be.visible");
-    cy.contains("Copy share link to selected lines").click();
+    // Need to fire a real click here because the copy to clipboard
+    cy.contains("Copy share link to selected lines").realClick();
     cy.validateToast("success", "Copied link to clipboard", true);
     cy.window().then((win) => {
       win.navigator.clipboard.readText().then((text) => {

--- a/cypress/integration/resmokeLogs/resmoke_logView.ts
+++ b/cypress/integration/resmokeLogs/resmoke_logView.ts
@@ -150,7 +150,8 @@ describe("Bookmarking and selecting lines", () => {
     const logLine11079 = `[j0:s1] | 2022-09-21T12:50:28.489+00:00 I  NETWORK  22944   [conn60] "Connection ended","attr":{"remote":"127.0.0.1:47362","uuid":{"uuid":{"$uuid":"b28d7d9f-03b6-4f93-a7cd-5e1948135f69"}},"connectionId":60,"connectionCount":2}`;
 
     cy.dataCy("details-button").click();
-    cy.dataCy("jira-button").click();
+    // Need to fire a real click here because the copy to clipboard
+    cy.dataCy("jira-button").realClick();
     cy.window().then((win) => {
       win.navigator.clipboard.readText().then((text) => {
         expect(text).to.eq(
@@ -289,7 +290,8 @@ describe("Sharing lines", () => {
     cy.dataCy("line-index-2").click({ shiftKey: true });
     cy.dataCy("sharing-menu").should("be.visible");
     cy.contains("Copy selected contents").should("be.visible");
-    cy.contains("Copy selected contents").click();
+    // Need to fire a real click here because the copy to clipboard
+    cy.contains("Copy selected contents").realClick();
     cy.validateToast("success", "Copied 2 lines to clipboard", true);
     cy.window().then((win) => {
       win.navigator.clipboard.readText().then((text) => {
@@ -304,7 +306,8 @@ describe("Sharing lines", () => {
     cy.dataCy("line-index-2").click({ shiftKey: true });
     cy.dataCy("sharing-menu").should("be.visible");
     cy.contains("Copy share link to selected lines").should("be.visible");
-    cy.contains("Copy share link to selected lines").click();
+    // Need to fire a real click here because the copy to clipboard
+    cy.contains("Copy share link to selected lines").realClick();
     cy.validateToast("success", "Copied link to clipboard", true);
     cy.window().then((win) => {
       win.navigator.clipboard.readText().then((text) => {

--- a/cypress/integration/resmokeLogs/resmoke_logView.ts
+++ b/cypress/integration/resmokeLogs/resmoke_logView.ts
@@ -152,13 +152,9 @@ describe("Bookmarking and selecting lines", () => {
     cy.dataCy("details-button").click();
     // Need to fire a real click here because the copy to clipboard
     cy.dataCy("jira-button").realClick();
-    cy.window().then((win) => {
-      win.navigator.clipboard.readText().then((text) => {
-        expect(text).to.eq(
-          `{noformat}\n${logLine0}\n...\n${logLine10}\n${logLine11}\n...\n${logLine11079}\n{noformat}`
-        );
-      });
-    });
+    cy.assertValueCopiedToClipboard(
+      `{noformat}\n${logLine0}\n...\n${logLine10}\n${logLine11}\n...\n${logLine11079}\n{noformat}`
+    );
   });
 
   it("should be able to clear bookmarks", () => {
@@ -293,13 +289,9 @@ describe("Sharing lines", () => {
     // Need to fire a real click here because the copy to clipboard
     cy.contains("Copy selected contents").realClick();
     cy.validateToast("success", "Copied 2 lines to clipboard", true);
-    cy.window().then((win) => {
-      win.navigator.clipboard.readText().then((text) => {
-        expect(text).to.eq(
-          `{noformat}\n+------------------------------------------+--------+-----+-----+\n|full_name                                 |name    |port |pid  |\n{noformat}`
-        );
-      });
-    });
+    cy.assertValueCopiedToClipboard(
+      `{noformat}\n+------------------------------------------+--------+-----+-----+\n|full_name                                 |name    |port |pid  |\n{noformat}`
+    );
   });
   it("should be able to copy a link to the selected lines", () => {
     cy.dataCy("line-index-1").click();
@@ -309,14 +301,9 @@ describe("Sharing lines", () => {
     // Need to fire a real click here because the copy to clipboard
     cy.contains("Copy share link to selected lines").realClick();
     cy.validateToast("success", "Copied link to clipboard", true);
-    cy.window().then((win) => {
-      win.navigator.clipboard.readText().then((text) => {
-        cy.log("text", text);
-        expect(text).to.eq(
-          "http://localhost:4173/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab?bookmarks=0%2C11079&selectedLineRange=L1-L2&shareLine=1"
-        );
-      });
-    });
+    cy.assertValueCopiedToClipboard(
+      "http://localhost:4173/resmoke/7e208050e166b1a9025c817b67eee48d/test/1716e11b4f8a4541c5e2faf70affbfab?bookmarks=0%2C11079&selectedLineRange=L1-L2&shareLine=1"
+    );
   });
   it("should be able to limit the search range to the selected lines", () => {
     cy.dataCy("line-index-1").click();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -184,3 +184,14 @@ Cypress.Commands.add(
     }
   }
 );
+
+Cypress.Commands.add("assertValueCopiedToClipboard", (value: string) => {
+  cy.window().then((win) => {
+    win.navigator.clipboard.readText().then((text) => {
+      expect(text).to.eq(value);
+    });
+  });
+  // This wait is necessary to ensure the clipboard has time to be read
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(50);
+});

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,3 +1,4 @@
+import "cypress-real-events";
 import "./commands";
 
 declare global {

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -91,6 +91,11 @@ declare global {
         message?: string,
         shouldClose?: boolean
       ): void;
+      /**
+       * Custom command to validate that a value was copied to the clipboard.
+       * @example cy.assertValueCopiedToClipboard("This is some text")
+       */
+      assertValueCopiedToClipboard(text: string): void;
     }
   }
 }

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "ES5",
     "lib": ["ES5", "DOM"],
-    "types": ["cypress", "node"],
+    "types": ["cypress", "node", "cypress-real-events"],
   },
   "include": ["**/*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "babel-loader": "8.2.5",
     "babel-plugin-import-graphql": "2.8.1",
     "cypress": "12.7.0",
-    "cypress-real-events": "^1.11.0",
+    "cypress-real-events": "1.11.0",
     "env-cmd": "10.1.0",
     "eslint": "8.31.0",
     "eslint-config-airbnb": "19.0.4",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "babel-loader": "8.2.5",
     "babel-plugin-import-graphql": "2.8.1",
     "cypress": "12.7.0",
+    "cypress-real-events": "^1.11.0",
     "env-cmd": "10.1.0",
     "eslint": "8.31.0",
     "eslint-config-airbnb": "19.0.4",

--- a/src/components/LogRow/AnsiRow/index.tsx
+++ b/src/components/LogRow/AnsiRow/index.tsx
@@ -1,6 +1,7 @@
 import { AnsiUp } from "ansi_up";
 import linkifyHtml from "linkify-html";
 import BaseRow from "components/LogRow/BaseRow";
+import { trimSeverity } from "utils/string";
 import { getSeverityMapping, mapLogLevelToColor } from "./utils";
 import { LogRowProps } from "../types";
 
@@ -21,7 +22,7 @@ const AnsiRow: React.FC<AnsiRowProps> = ({ getLine, lineNumber, ...rest }) => {
 
   if (severity) {
     // Trim "[P: NN] " priority prefix
-    lineContent = lineContent.substring(8);
+    lineContent = trimSeverity(lineContent);
   }
 
   const linkifiedLine = linkifyHtml(ansiUp.ansi_to_html(lineContent ?? ""), {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -378,6 +378,7 @@ export type Distro = {
   iceCreamSettings: IceCreamSettings;
   isCluster: Scalars["Boolean"]["output"];
   isVirtualWorkStation: Scalars["Boolean"]["output"];
+  mountpoints: Array<Maybe<Scalars["String"]["output"]>>;
   name: Scalars["String"]["output"];
   note: Scalars["String"]["output"];
   plannerSettings: PlannerSettings;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1048,6 +1048,7 @@ export type Mutation = {
   scheduleTasks: Array<Task>;
   scheduleUndispatchedBaseTasks?: Maybe<Array<Task>>;
   setAnnotationMetadataLinks: Scalars["Boolean"]["output"];
+  setLastRevision: SetLastRevisionPayload;
   setPatchPriority?: Maybe<Scalars["String"]["output"]>;
   /** setPatchVisibility takes a list of patch ids and a boolean to set the visibility on the my patches queries */
   setPatchVisibility: Array<Patch>;
@@ -1271,6 +1272,10 @@ export type MutationSetAnnotationMetadataLinksArgs = {
   execution: Scalars["Int"]["input"];
   metadataLinks: Array<MetadataLinkInput>;
   taskId: Scalars["String"]["input"];
+};
+
+export type MutationSetLastRevisionArgs = {
+  opts: SetLastRevisionInput;
 };
 
 export type MutationSetPatchPriorityArgs = {
@@ -1539,11 +1544,16 @@ export type Permissions = {
   canCreateProject: Scalars["Boolean"]["output"];
   canEditAdminSettings: Scalars["Boolean"]["output"];
   distroPermissions: DistroPermissions;
+  projectPermissions: ProjectPermissions;
   userId: Scalars["String"]["output"];
 };
 
 export type PermissionsDistroPermissionsArgs = {
   options: DistroPermissionsOptions;
+};
+
+export type PermissionsProjectPermissionsArgs = {
+  options: ProjectPermissionsOptions;
 };
 
 export type PlannerSettings = {
@@ -1817,6 +1827,16 @@ export type ProjectInput = {
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   workstationConfig?: InputMaybe<WorkstationConfigInput>;
+};
+
+export type ProjectPermissions = {
+  __typename?: "ProjectPermissions";
+  edit: Scalars["Boolean"]["output"];
+  view: Scalars["Boolean"]["output"];
+};
+
+export type ProjectPermissionsOptions = {
+  projectIdentifier: Scalars["String"]["input"];
 };
 
 /** ProjectSettings models the settings for a given Project. */
@@ -2278,6 +2298,20 @@ export type Selector = {
 export type SelectorInput = {
   data: Scalars["String"]["input"];
   type: Scalars["String"]["input"];
+};
+
+/**
+ * SetLastRevisionInput is the input to the setLastRevision mutation.
+ * It contains information used to fix the repotracker error of a project.
+ */
+export type SetLastRevisionInput = {
+  projectIdentifier: Scalars["String"]["input"];
+  revision: Scalars["String"]["input"];
+};
+
+export type SetLastRevisionPayload = {
+  __typename?: "SetLastRevisionPayload";
+  mergeBaseRevision: Scalars["String"]["output"];
 };
 
 export type SlackConfig = {

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -31,7 +31,7 @@ export const getJiraFormat = (
       break;
     }
 
-    jiraString += `${logText}\n`;
+    jiraString += `${trimSeverity(logText)}\n`;
 
     // If the current and next indices are not adjacent to each other, insert an
     // ellipsis in between them.
@@ -112,6 +112,18 @@ export const getBytesAsString = (bytes: number, decimals = 2) => {
 export const trimLogLineToMaxSize = (line: string, maxSize: number) => {
   if (line.length > maxSize) {
     return `${line.substring(0, maxSize)}…`;
+  }
+  return line;
+};
+
+/**
+ * `trimSeverity` trims the severity prefix from a line
+ * @param line - the line to trim
+ * @returns - the line without the severity prefix
+ */
+export const trimSeverity = (line: string) => {
+  if (line.startsWith("[P: ")) {
+    return line.substring(8);
   }
   return line;
 };

--- a/src/utils/string/string.test.ts
+++ b/src/utils/string/string.test.ts
@@ -5,6 +5,7 @@ import {
   shortenGithash,
   stringIntersection,
   trimLogLineToMaxSize,
+  trimSeverity,
   trimStringFromMiddle,
 } from ".";
 
@@ -128,5 +129,34 @@ describe("trimLogLineToMaxSize", () => {
   });
   it("should trim a log and add an ellipsis if it is longer than the max size", () => {
     expect(trimLogLineToMaxSize("1234", 3)).toBe("123…");
+  });
+});
+
+describe("trimSeverity", () => {
+  it("should trim the severity prefix from a line", () => {
+    expect(
+      trimSeverity(
+        "[P: 40] [2022/12/05 20:03:30.136] Running pre-task commands."
+      )
+    ).toBe("[2022/12/05 20:03:30.136] Running pre-task commands.");
+    expect(
+      trimSeverity(
+        "[P: 70] [2022/12/05 20:03:30.138] + '[' amazon2-cloud-small = amazon2-cloud-large ']'"
+      )
+    ).toBe(
+      "[2022/12/05 20:03:30.138] + '[' amazon2-cloud-small = amazon2-cloud-large ']'"
+    );
+  });
+  it("should not trim the string if the severity prefix is not present", () => {
+    expect(
+      trimSeverity("[2022/12/05 20:03:30.136] Running pre-task commands.")
+    ).toBe("[2022/12/05 20:03:30.136] Running pre-task commands.");
+    expect(
+      trimSeverity(
+        "[2022/12/05 20:03:30.138] + '[' amazon2-cloud-small = amazon2-cloud-large ']'"
+      )
+    ).toBe(
+      "[2022/12/05 20:03:30.138] + '[' amazon2-cloud-small = amazon2-cloud-large ']'"
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7792,6 +7792,11 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
   integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
 
+cypress-real-events@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.11.0.tgz#292fe5281c5b6e955524e766ab7fec46930c7763"
+  integrity sha512-4LXVRsyq+xBh5TmlEyO1ojtBXtN7xw720Pwb9rEE9rkJuXmeH3VyoR1GGayMGr+Itqf11eEjfDewtDmcx6PWPQ==
+
 cypress@12.7.0:
   version "12.7.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.7.0.tgz#69900f82af76cf3ba0ddb9b59ec3b0d38222ab22"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7792,7 +7792,7 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
   integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
 
-cypress-real-events@^1.11.0:
+cypress-real-events@1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.11.0.tgz#292fe5281c5b6e955524e766ab7fec46930c7763"
   integrity sha512-4LXVRsyq+xBh5TmlEyO1ojtBXtN7xw720Pwb9rEE9rkJuXmeH3VyoR1GGayMGr+Itqf11eEjfDewtDmcx6PWPQ==


### PR DESCRIPTION
DEVPROD-1904

### Description 
The test flake here seems to have been caused by an assertion that would sometimes race with the click because it wasn't checking if the element existed.
There were also some silent uncaught exceptions that were caused by clicking on a copy to clipboard button because the cypress click event isn't a real click and the browser prevents copying to the clipboard without a real user interaction. 
It also looks like the actual copy assertions themselves weren't being resolved during the test and would leak into the next test run causing unpredictable behavior. I moved the the copy assertion to a util function and added a wait to ensure it gets run before the test completes

