### PR TITLE
DEVPROD-2917: Add goroot expansion

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -506,6 +506,7 @@ buildvariants:
   - name: ubuntu2204-small
     display_name: Ubuntu 22.04 (small)
     expansions:
+      goroot: /opt/golang/go1.20
       mongodb_url_70: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.2.tgz
       mongosh_url: https://downloads.mongodb.com/compass/mongosh-2.0.2-linux-x64.tgz
       node_version: 16.17.0
@@ -523,6 +524,7 @@ buildvariants:
   - name: ubuntu2204-large
     display_name: Ubuntu 22.04 (large)
     expansions:
+      goroot: /opt/golang/go1.20
       mongodb_url_70: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.2.tgz
       mongosh_url: https://downloads.mongodb.com/compass/mongosh-2.0.2-linux-x64.tgz
       node_version: 16.17.0


### PR DESCRIPTION
DEVPROD-2917

### Description 
<!-- Add description, context, thought process, etc -->
- Add upgraded `goroot` expansion to replace the `goroot` var in project settings. I prefer .evergreen.yml variables because they allow upgrades to be tested first.