### PR TITLE
DEVPROD-821: Rename wiki navbar link

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -8,7 +8,7 @@ import Icon from "components/Icon";
 import Search from "components/Search";
 import ShortcutModal from "components/ShortcutModal";
 import { StyledLink } from "components/styles";
-import { wikiURL } from "constants/externalLinks";
+import { docsURL } from "constants/externalLinks";
 import { navbarHeight, size } from "constants/tokens";
 import { useAuthContext } from "context/auth";
 import { useLogContext } from "context/LogContext";
@@ -27,7 +27,7 @@ const NavBar: React.FC = () => {
       <FlexContainer>
         <Logo glyph="ParsleyLogo" size={24} useStroke />
         <LinkContainer>
-          <StyledLink href={wikiURL}>Wiki</StyledLink>
+          <StyledLink href={docsURL}>Documentation</StyledLink>
           <UploadLink clearLogs={clearLogs} hasLogs={hasLogs} />
         </LinkContainer>
         <Search />

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -27,7 +27,7 @@ const NavBar: React.FC = () => {
       <FlexContainer>
         <Logo glyph="ParsleyLogo" size={24} useStroke />
         <LinkContainer>
-          <StyledLink href={docsURL}>Documentation</StyledLink>
+          <StyledLink href={docsURL}>Docs</StyledLink>
           <UploadLink clearLogs={clearLogs} hasLogs={hasLogs} />
         </LinkContainer>
         <Search />

--- a/src/constants/externalLinks.ts
+++ b/src/constants/externalLinks.ts
@@ -1,3 +1,3 @@
-const wikiURL = "https://docs.devprod.prod.corp.mongodb.com/parsley/Home";
+const docsURL = "https://docs.devprod.prod.corp.mongodb.com/parsley/Home";
 
-export { wikiURL };
+export { docsURL };


### PR DESCRIPTION
DEVPROD-821

### Description 
<!-- Add description, context, thought process, etc -->
- Rename `Wiki` ➡️ `Documentation`

### Screenshots
<!-- Add screenshots of visible changes -->
<img width="1406" alt="image" src="https://github.com/evergreen-ci/parsley/assets/9298431/3751d45d-4c50-41c2-b2b4-cc300986aee2">