### PR TITLE
DEVPROD-3290 Support using vite dev server when using cypress

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,12 @@ import { defineConfig } from "vite";
 import checker from "vite-plugin-checker";
 import envCompatible from "vite-plugin-env-compatible";
 import tsconfigPaths from "vite-tsconfig-paths";
+import dns from "dns";
 import path from "path";
 import injectVariablesInHTML from "./config/injectVariablesInHTML";
+
+// Remove when https://github.com/cypress-io/cypress/issues/25397 is resolved.
+dns.setDefaultResultOrder("ipv4first");
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
DEVPROD-3290

### Description 
Makes the same change from https://github.com/evergreen-ci/spruce/pull/2136

