### PR TITLE
DEVPROD-921: Don't overflow bookmark bar

### DIFF
--- a/src/components/BookmarksBar/__snapshots__/BookmarksBar.stories.storyshot
+++ b/src/components/BookmarksBar/__snapshots__/BookmarksBar.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Snapshot Tests BookmarksBar.stories Default 1`] = `
     class="css-3ieiu4"
   >
     <div
-      class="css-1alexgg"
+      class="css-c94c4y"
     >
       <button
         aria-disabled="false"

--- a/src/components/BookmarksBar/index.tsx
+++ b/src/components/BookmarksBar/index.tsx
@@ -128,7 +128,8 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
 
-  width: ${size.xl};
+  min-width: ${size.xl};
+  width: fit-content;
   background-color: ${gray.light3};
   box-shadow: 0 ${size.xxs} ${size.xxs} rgba(0, 0, 0, 0.25);
   padding-top: ${size.s};

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -430,8 +430,7 @@ export type DistroInfo = {
 };
 
 export type DistroInput = {
-  /** TODO: require adminOnly field upon completion of DEVPROD-3533 */
-  adminOnly?: InputMaybe<Scalars["Boolean"]["input"]>;
+  adminOnly: Scalars["Boolean"]["input"];
   aliases: Array<Scalars["String"]["input"]>;
   arch: Arch;
   authorizedKeysFile: Scalars["String"]["input"];


### PR DESCRIPTION
DEVPROD-921

### Description 
<!-- Add description, context, thought process, etc -->
- Ensure width of bookmarks bar fits contents

### Screenshots
<!-- Add screenshots of visible changes -->
<img width="111" alt="image" src="https://github.com/evergreen-ci/parsley/assets/9298431/746de42f-cb9a-4021-b31f-39fca58cdfd1">