### PR TITLE
DEVPROD-5097: Prevent deploy-prod task from failing silently

### DIFF
--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -1,8 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script runs the AWS CLI command to deploy the app to S3.
 
-# Try this step and throw an error if it fails
 echo "Deploying to S3"
-aws s3 sync dist/ s3://"${BUCKET}"/ --acl public-read --follow-symlinks --delete --exclude .env-cmdrc.json 
-echo "Deployed to S3"
+
+if ! aws s3 sync dist/ s3://"${BUCKET}"/ --acl public-read --follow-symlinks --delete --exclude .env-cmdrc.json; then
+  echo "Deployment to S3 failed"
+  exit 1
+else
+  echo "Successfully deployed to S3"
+fi


### PR DESCRIPTION
DEVPROD-5097

### Description 
The `deploy-prod` task succeeds even if this command fails. We should error and exit on failure.

Important note: We use `dist` folder, not `build` folder, in Parsley.
