### PR TITLE
DEVPROD-787: Retry Node installation on CI

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -227,6 +227,7 @@ functions:
         shell: bash
         script: |
           ${PREPARE_SHELL}
+
           # Fetch NVM and install it into this task's .nvm directory
           # Once downloaded, source nvm and install yarn
           git clone https://github.com/nvm-sh/nvm.git "$NVM_DIR"
@@ -234,7 +235,14 @@ functions:
           git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --tags --max-count=1)`
           [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
           cd -
-          nvm install --no-progress --default ${node_version}
+          
+          # Retry the download for Node in case it flakes.
+          for i in {1..5}; do
+            nvm install --no-progress --default ${node_version}
+            [[ $? -eq 0 ]] && break
+            echo "Attempt $i of 5 to install Node failed"
+            sleep 10
+          done
           npm install -g yarn
 
   sym-link:


### PR DESCRIPTION
DEVPROD-787

### Description 
Copied changes from evergreen-ci/spruce/pull/2281.

### Testing 
- [Patch](https://spruce.mongodb.com/task/parsley_ubuntu2204_small_lint_patch_0dda172225f653b5c3f511a8438b2e3f675cb264_65e22e09c9ec44d9ba8af418_24_03_01_19_35_46/logs?execution=0) which shows printed messages

