### PR TITLE
DEVPROD-803 Add support for copying and pasting logs into parsley

### DIFF
--- a/src/analytics/logDrop/useLogDropAnalytics.ts
+++ b/src/analytics/logDrop/useLogDropAnalytics.ts
@@ -5,6 +5,7 @@ type Action =
   | { name: "Clicked Upload Link"; hasLogs: boolean }
   | { name: "Dropped file" }
   | { name: "Uploaded Log File With Picker" }
+  | { name: "Pasted text" }
   | { name: "Processed Log"; logType: LogTypes; fileSize?: number };
 
 export const useLogDropAnalytics = () => useAnalyticsRoot<Action>("LogDrop");

--- a/src/hooks/useClipboardPaste/index.ts
+++ b/src/hooks/useClipboardPaste/index.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect } from "react";
 
 /**
- * `useClipboardPaste` is a custom hook that listens for a paste event and calls a callback with the pasted text.
+ * `useClipboardPaste` listens for a paste event and calls a callback with the pasted text.
  * @param callback - a function that takes a string as an argument
  */
 const useClipboardPaste = (callback: (text: string) => void): void => {
-  const pasteListener = useCallback(
+  const handlePaste = useCallback(
     (event: ClipboardEvent) => {
       navigator.clipboard.readText().then(callback);
       event.preventDefault();
@@ -14,11 +14,11 @@ const useClipboardPaste = (callback: (text: string) => void): void => {
   );
 
   useEffect(() => {
-    window.addEventListener("paste", pasteListener);
+    window.addEventListener("paste", handlePaste);
     return () => {
-      window.removeEventListener("paste", pasteListener);
+      window.removeEventListener("paste", handlePaste);
     };
-  }, [pasteListener]);
+  }, [handlePaste]);
 };
 
 export default useClipboardPaste;

--- a/src/hooks/useClipboardPaste/index.ts
+++ b/src/hooks/useClipboardPaste/index.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect } from "react";
+
+/**
+ * `useClipboardPaste` is a custom hook that listens for a paste event and calls a callback with the pasted text.
+ * @param callback - a function that takes a string as an argument
+ */
+const useClipboardPaste = (callback: (text: string) => void): void => {
+  const pasteListener = useCallback(
+    (event: ClipboardEvent) => {
+      navigator.clipboard.readText().then(callback);
+      event.preventDefault();
+    },
+    [callback],
+  );
+
+  useEffect(() => {
+    window.addEventListener("paste", pasteListener);
+    return () => {
+      window.removeEventListener("paste", pasteListener);
+    };
+  }, [pasteListener]);
+};
+
+export default useClipboardPaste;

--- a/src/hooks/useClipboardPaste/useClipboardPaste.test.ts
+++ b/src/hooks/useClipboardPaste/useClipboardPaste.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from "test_utils";
-import useClipboardPaste from "."; // Adjust the import path as necessary
+import useClipboardPaste from ".";
 
 // Mock navigator.clipboard.readText
 const mockReadText = jest.fn();
@@ -22,18 +22,15 @@ describe("useClipboardPaste", () => {
     const callback = jest.fn();
     renderHook(() => useClipboardPaste(callback));
 
-    // Setup the mocked readText function to return a specific string
     const expectedText = "Pasted content";
     mockReadText.mockResolvedValue(expectedText);
 
-    // Simulate a paste event
     const event = new Event("paste");
     window.dispatchEvent(event);
 
     // Wait for the promise to resolve
     await new Promise(process.nextTick);
 
-    // Check if the callback was called with the expected text
     expect(callback).toHaveBeenCalledWith(expectedText);
   });
 

--- a/src/hooks/useClipboardPaste/useClipboardPaste.test.ts
+++ b/src/hooks/useClipboardPaste/useClipboardPaste.test.ts
@@ -1,0 +1,53 @@
+import { renderHook } from "test_utils";
+import useClipboardPaste from "."; // Adjust the import path as necessary
+
+// Mock navigator.clipboard.readText
+const mockReadText = jest.fn();
+
+describe("useClipboardPaste", () => {
+  beforeAll(() => {
+    // Define a global.navigator.clipboard object if it doesn't exist
+    Object.assign(navigator, {
+      clipboard: {
+        readText: mockReadText,
+      },
+    });
+  });
+
+  beforeEach(() => {
+    // Clear mock history before each test
+    mockReadText.mockClear();
+  });
+  it("calls the callback with pasted text on paste event", async () => {
+    const callback = jest.fn();
+    renderHook(() => useClipboardPaste(callback));
+
+    // Setup the mocked readText function to return a specific string
+    const expectedText = "Pasted content";
+    mockReadText.mockResolvedValue(expectedText);
+
+    // Simulate a paste event
+    const event = new Event("paste");
+    window.dispatchEvent(event);
+
+    // Wait for the promise to resolve
+    await new Promise(process.nextTick);
+
+    // Check if the callback was called with the expected text
+    expect(callback).toHaveBeenCalledWith(expectedText);
+  });
+
+  it("removes the paste event listener on unmount", () => {
+    const callback = jest.fn();
+    const { unmount } = renderHook(() => useClipboardPaste(callback));
+
+    unmount();
+
+    // Simulate a paste event after unmounting
+    const event = new Event("paste");
+    window.dispatchEvent(event);
+
+    // Since the component is unmounted, callback should not be called
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/LogDrop/FileDropper.tsx
+++ b/src/pages/LogDrop/FileDropper.tsx
@@ -9,6 +9,7 @@ import { LOG_FILE_SIZE_LIMIT, LOG_LINE_SIZE_LIMIT } from "constants/logs";
 import { size } from "constants/tokens";
 import { useLogContext } from "context/LogContext";
 import { useToastContext } from "context/toast";
+import useClipboardPaste from "hooks/useClipboardPaste";
 import {
   SentryBreadcrumb,
   leaveBreadcrumb,
@@ -29,6 +30,12 @@ const FileDropper: React.FC = () => {
   const { ingestLines, setFileName, setLogMetadata } = useLogContext();
   const [, startTransition] = useTransition();
   const { dispatch, state } = useLogDropState();
+  const onClipboardPaste = useCallback((text: string) => {
+    leaveBreadcrumb("Pasted text", {}, SentryBreadcrumb.User);
+    sendEvent({ name: "Pasted text" });
+    dispatch({ text, type: "PASTED_TEXT" });
+  }, []);
+  useClipboardPaste(onClipboardPaste);
 
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {
@@ -55,37 +62,53 @@ const FileDropper: React.FC = () => {
         dispatch({ type: "PARSE_FILE" });
         startTransition(() => {
           (async () => {
-            if (state.file) {
-              try {
-                const stream = await fileToStream(state.file, {
-                  fileSizeLimit: LOG_FILE_SIZE_LIMIT,
-                });
-                const { result: logLines, trimmedLines } = await decodeStream(
-                  stream,
-                  LOG_LINE_SIZE_LIMIT,
-                );
-                leaveBreadcrumb(
-                  "Decoded file",
-                  { fileSize: logLines.length },
-                  SentryBreadcrumb.UI,
-                );
-                sendEvent({
-                  fileSize: logLines?.length,
-                  logType,
-                  name: "Processed Log",
-                });
-                setFileName(state.file.name);
-                ingestLines(logLines, logType);
-                if (trimmedLines) {
-                  dispatchToast.warning(LOG_LINE_TOO_LARGE_WARNING, true, {
-                    shouldTimeout: false,
-                    title: "Log not fully loaded",
-                  });
+            switch (state.type) {
+              case "file":
+                if (state.file) {
+                  try {
+                    const stream = await fileToStream(state.file, {
+                      fileSizeLimit: LOG_FILE_SIZE_LIMIT,
+                    });
+                    const { result: logLines, trimmedLines } =
+                      await decodeStream(stream, LOG_LINE_SIZE_LIMIT);
+                    leaveBreadcrumb(
+                      "Decoded file",
+                      { fileSize: logLines.length },
+                      SentryBreadcrumb.Info,
+                    );
+                    sendEvent({
+                      fileSize: logLines?.length,
+                      logType,
+                      name: "Processed Log",
+                    });
+                    setFileName(state.file.name);
+                    ingestLines(logLines, logType);
+                    if (trimmedLines) {
+                      dispatchToast.warning(LOG_LINE_TOO_LARGE_WARNING, true, {
+                        shouldTimeout: false,
+                        title: "Log not fully loaded",
+                      });
+                    }
+                  } catch (e: any) {
+                    dispatchToast.error(
+                      "An error occurred while parsing the log.",
+                    );
+                    reportError(e).severe();
+                  }
                 }
-              } catch (e: any) {
-                dispatchToast.error("An error occurred while parsing the log.");
-                reportError(e).severe();
-              }
+                break;
+              case "text":
+                if (state.text) {
+                  const logLines = state.text.split("\n");
+                  setFileName("Pasted Log");
+                  ingestLines(logLines, logType);
+                }
+                break;
+              default:
+                reportError(
+                  new Error(`Invalid state type: ${state.type}`),
+                ).severe();
+                break;
             }
           })();
         });
@@ -95,6 +118,7 @@ const FileDropper: React.FC = () => {
       setLogMetadata,
       dispatch,
       state.file,
+      state.type,
       sendEvent,
       setFileName,
       ingestLines,
@@ -120,6 +144,7 @@ const FileDropper: React.FC = () => {
       visibleUI = (
         <ParseLogSelect
           fileName={state.file?.name || ""}
+          isPastedFile={state.type === "text"}
           onCancel={() => dispatch({ type: "CANCEL" })}
           onParse={onParse}
         />

--- a/src/pages/LogDrop/FileSelector/index.tsx
+++ b/src/pages/LogDrop/FileSelector/index.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import Button from "@leafygreen-ui/button";
-import { Body } from "@leafygreen-ui/typography";
+import { Body, InlineKeyCode } from "@leafygreen-ui/typography";
 import { DropzoneInputProps } from "react-dropzone";
 import Icon from "components/Icon";
 import { size } from "constants/tokens";
@@ -13,7 +13,12 @@ interface FileSelectorProps {
 const FileSelector: React.FC<FileSelectorProps> = ({ getInputProps, open }) => (
   <FileSelectorContainer>
     <input {...getInputProps()} />
-    <Body weight="medium">Drag and Drop a log file to view in Parsley</Body>
+    <Body weight="medium">Drag and Drop a log file</Body>
+    <Body weight="medium">or</Body>
+    <Body weight="medium">
+      <InlineKeyCode>⌘</InlineKeyCode> + <InlineKeyCode>V</InlineKeyCode> to
+      paste text from your clipboard
+    </Body>
     <Body weight="medium">or</Body>
     <Button
       leftGlyph={<Icon glyph="Upload" />}
@@ -32,7 +37,7 @@ const FileSelectorContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: ${size.xs};
+  gap: ${size.xxs};
 `;
 
 export default FileSelector;

--- a/src/pages/LogDrop/ParseLogSelect/ParseLogSelect.test.tsx
+++ b/src/pages/LogDrop/ParseLogSelect/ParseLogSelect.test.tsx
@@ -12,6 +12,7 @@ describe("parse log select", () => {
     render(
       <ParseLogSelect
         fileName="filename.txt"
+        isPastedFile={false}
         onCancel={jest.fn()}
         onParse={jest.fn()}
       />,
@@ -28,6 +29,7 @@ describe("parse log select", () => {
     render(
       <ParseLogSelect
         fileName="filename.txt"
+        isPastedFile={false}
         onCancel={jest.fn()}
         onParse={jest.fn()}
       />,
@@ -41,6 +43,7 @@ describe("parse log select", () => {
     render(
       <ParseLogSelect
         fileName="filename.txt"
+        isPastedFile={false}
         onCancel={jest.fn()}
         onParse={jest.fn()}
       />,
@@ -56,6 +59,7 @@ describe("parse log select", () => {
     render(
       <ParseLogSelect
         fileName="filename.txt"
+        isPastedFile={false}
         onCancel={jest.fn()}
         onParse={onParse}
       />,
@@ -70,6 +74,7 @@ describe("parse log select", () => {
     render(
       <ParseLogSelect
         fileName="filename.txt"
+        isPastedFile={false}
         onCancel={onCancel}
         onParse={jest.fn()}
       />,

--- a/src/pages/LogDrop/ParseLogSelect/index.tsx
+++ b/src/pages/LogDrop/ParseLogSelect/index.tsx
@@ -12,6 +12,7 @@ interface ParseLogSelectProps {
   fileName: string | undefined;
   onParse: (logType: LogRenderingTypes | undefined) => void;
   onCancel: () => void;
+  isPastedFile: boolean;
 }
 
 type SelectState =
@@ -21,6 +22,7 @@ type SelectState =
 
 const ParseLogSelect: React.FC<ParseLogSelectProps> = ({
   fileName,
+  isPastedFile,
   onCancel,
   onParse,
 }) => {
@@ -32,7 +34,12 @@ const ParseLogSelect: React.FC<ParseLogSelectProps> = ({
     <ProcessLogsContainer>
       <Label htmlFor="parse-log-select">
         How would you like to parse{" "}
-        <StyledInlineCode>{fileName}</StyledInlineCode>?
+        {isPastedFile ? (
+          "the pasted file"
+        ) : (
+          <StyledInlineCode>{fileName}</StyledInlineCode>
+        )}
+        ?
       </Label>
       <Select
         aria-labelledby="parse-log-select"

--- a/src/pages/LogDrop/state.ts
+++ b/src/pages/LogDrop/state.ts
@@ -9,15 +9,20 @@ type CurrentState =
 type State = {
   currentState: CurrentState;
   file: File | null;
+  text: string | null;
+  type: "file" | "text" | null;
 };
 type Action =
   | { type: "DROPPED_FILE"; file: File }
+  | { type: "PASTED_TEXT"; text: string }
   | { type: "PARSE_FILE" }
   | { type: "CANCEL" };
 
 const initialState = (): State => ({
   currentState: "WAITING_FOR_FILE",
   file: null,
+  text: null,
+  type: null,
 });
 
 const reducer = (state: State, action: Action): State => {
@@ -27,14 +32,23 @@ const reducer = (state: State, action: Action): State => {
         ...state,
         currentState: "PROMPT_FOR_PARSING_METHOD",
         file: action.file,
+        type: "file",
       };
     case "PARSE_FILE":
       return {
         ...state,
         currentState: "LOADING_FILE",
       };
+    case "PASTED_TEXT":
+      return {
+        ...state,
+        currentState: "PROMPT_FOR_PARSING_METHOD",
+        text: action.text,
+        type: "text",
+      };
     case "CANCEL":
       return initialState();
+
     default:
       throw new Error(`Unknown reducer action ${action}`);
   }


### PR DESCRIPTION
DEVPROD-803

### Description 
Adds support to copy and paste files into Parsley from the upload page. 
Went against the approach of including a text box because the UX didn't work and pasting a large file into a text box causes the browser to freeze up.

### Screenshots
![image](https://github.com/evergreen-ci/parsley/assets/4605522/3b085a50-99c6-49cd-b616-9ee9be8c1fa9)

### Testing 
Unit tests.
I'm still figuring out how to write cypress tests since the paste event doesn't seem to be supported

