### PR TITLE
DEVPROD-5665 Update cypress e2e task to not report to cypress cloud

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -277,7 +277,12 @@ functions:
       shell: bash
       script: |
         ${PREPARE_SHELL}
-        yarn cy:run --reporter junit
+        # Allow spec filtering for an intentional patch.
+        if [[ "${requester}" == "patch" ]]; then
+          yarn cy:run --reporter junit --spec "${cypress_spec}"
+        else
+          yarn cy:run --reporter junit
+        fi
 
 
   yarn-eslint:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -583,3 +583,8 @@ post:
   - func: attach-logkeeper-logs
   - func: attach-test-results
   - func: attach-codegen-diff
+
+parameters:
+  - key: cypress_spec
+    value: cypress/integration/**/*
+    description: Specify the Cypress spec files to run for user submitted patches running the e2e_test task.

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -277,12 +277,8 @@ functions:
       shell: bash
       script: |
         ${PREPARE_SHELL}
-        # Only record to cypress cloud if this is a pr or a mainline commit.
-        if [[ "${requester}" == "github_pr" || "${requester}" == "commit" || "$requester" == "patch" ]]; then
-          yarn cy:run --record --key "${parsley_cypress_record_key}" --reporter junit
-        else
-          yarn cy:run --reporter junit
-        fi
+        yarn cy:run --reporter junit
+
 
   yarn-eslint:
     command: shell.exec

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -699,6 +699,7 @@ export type Host = {
   instanceType?: Maybe<Scalars["String"]["output"]>;
   lastCommunicationTime?: Maybe<Scalars["Time"]["output"]>;
   noExpiration: Scalars["Boolean"]["output"];
+  persistentDnsName: Scalars["String"]["output"];
   provider: Scalars["String"]["output"];
   runningTask?: Maybe<TaskInfo>;
   startedBy: Scalars["String"]["output"];
@@ -1057,6 +1058,7 @@ export type Mutation = {
   unschedulePatchTasks?: Maybe<Scalars["String"]["output"]>;
   unscheduleTask: Task;
   updateHostStatus: Scalars["Int"]["output"];
+  updateParsleySettings?: Maybe<UpdateParsleySettingsPayload>;
   updatePublicKey: Array<PublicKey>;
   updateSpawnHostStatus: Host;
   updateUserSettings: Scalars["Boolean"]["output"];
@@ -1315,6 +1317,10 @@ export type MutationUpdateHostStatusArgs = {
   status: Scalars["String"]["input"];
 };
 
+export type MutationUpdateParsleySettingsArgs = {
+  opts: UpdateParsleySettingsInput;
+};
+
 export type MutationUpdatePublicKeyArgs = {
   targetKeyName: Scalars["String"]["input"];
   updateInfo: PublicKeyInput;
@@ -1404,6 +1410,16 @@ export type ParsleyFilterInput = {
   caseSensitive: Scalars["Boolean"]["input"];
   exactMatch: Scalars["Boolean"]["input"];
   expression: Scalars["String"]["input"];
+};
+
+/** ParsleySettings contains information about a user's settings for Parsley. */
+export type ParsleySettings = {
+  __typename?: "ParsleySettings";
+  sectionsEnabled: Scalars["Boolean"]["output"];
+};
+
+export type ParsleySettingsInput = {
+  sectionsEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 /** Patch is a manually initiated version submitted to test local code changes. */
@@ -2866,6 +2882,15 @@ export type UiConfig = {
   userVoice?: Maybe<Scalars["String"]["output"]>;
 };
 
+export type UpdateParsleySettingsInput = {
+  parsleySettings: ParsleySettingsInput;
+};
+
+export type UpdateParsleySettingsPayload = {
+  __typename?: "UpdateParsleySettingsPayload";
+  parsleySettings?: Maybe<ParsleySettings>;
+};
+
 /**
  * UpdateVolumeInput is the input to the updateVolume mutation.
  * Its fields determine how a given volume will be modified.
@@ -2912,6 +2937,7 @@ export type User = {
   displayName: Scalars["String"]["output"];
   emailAddress: Scalars["String"]["output"];
   parsleyFilters: Array<ParsleyFilter>;
+  parsleySettings: ParsleySettings;
   patches: Patches;
   permissions: Permissions;
   subscriptions?: Maybe<Array<GeneralSubscription>>;


### PR DESCRIPTION
DEVPROD-5665

### Description 
irt the slack thread we will no longer be sending data to cypress cloud. 

### Testing 
The associated task still displays all of the necessary logs and links to files in the files tab
