### PR TITLE
DEVPROD-5759: Upgrade GraphQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@leafygreen-ui/typography": "16.5.0",
     "@sentry/react": "7.84.0",
     "ansi_up": "6.0.2",
-    "graphql": "16.6.0",
+    "graphql": "16.8.1",
     "html-react-parser": "3.0.6",
     "js-cookie": "3.0.5",
     "linkify-html": "4.1.3",

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -347,7 +347,6 @@ export type DispatcherSettingsInput = {
 };
 
 export enum DispatcherVersion {
-  Revised = "REVISED",
   RevisedWithDependencies = "REVISED_WITH_DEPENDENCIES",
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9536,10 +9536,10 @@ graphql-ws@^5.14.0:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.14.0.tgz#766f249f3974fc2c48fae0d1fb20c2c4c79cd591"
   integrity sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==
 
-graphql@16.6.0:
-  version "16.6.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
-  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
+graphql@16.8.1:
+  version "16.8.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
+  integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==
 
 gunzip-maybe@^1.4.2:
   version "1.4.2"


### PR DESCRIPTION
DEVPROD-5759

### Description 
<!-- Add description, context, thought process, etc -->
- Upgrade Parsley to same GraphQL version as Spruce ahead of monorepo merge

### Testing 
<!-- Add a description of how you tested it -->
- Verified in sandbox monorepo that this upgrade is necessary for GraphQL linting to work properly